### PR TITLE
Remove unused code declarations

### DIFF
--- a/src/reminderedit.h
+++ b/src/reminderedit.h
@@ -40,8 +40,6 @@ private:
     QJsonObject reminderData;
     QDateTime nextTriggerTime;
 
-    static QStringList categories;
-    static const QString CATEGORIES_FILE;
 };
 
 #endif // REMINDEREDIT_H 

--- a/src/reminderlist.h
+++ b/src/reminderlist.h
@@ -46,8 +46,6 @@ private:
     void setupModel();
     void addReminderToModel(const QJsonObject &reminder);
     void updateReminderInModel(const QJsonObject &reminder);
-    void loadReminders();
-    void saveReminders();
 
     Ui::ReminderList *ui;
     ReminderManager *reminderManager;

--- a/src/remindermanager.cpp
+++ b/src/remindermanager.cpp
@@ -221,16 +221,6 @@ void ReminderManager::showNotification(const Reminder &reminder)
     trayIcon->showMessage(tr("EasyNotify"), message, icon, duration);
 }
 
-void ReminderManager::updateReminderNextTrigger(const QString &id, const QDateTime &nextTrigger)
-{
-    for (Reminder &reminder : m_reminders) {
-        if (reminder.id() == id) {
-            reminder.setNextTrigger(nextTrigger);
-            saveReminders();
-            break;
-        }
-    }
-}
 
 QJsonArray ReminderManager::getRemindersJson() const
 {

--- a/src/remindermanager.h
+++ b/src/remindermanager.h
@@ -7,7 +7,6 @@
 #include <QJsonObject>
 #include <QJsonArray>
 #include <QJsonDocument>
-#include <QMap>
 #include "NotificationPopup.h"
 #include <QVector>
 #include "reminder.h"
@@ -46,11 +45,7 @@ private:
     void calculateNextTrigger(Reminder &reminder);
     bool shouldTrigger(const Reminder &reminder) const;
     void showNotification(const Reminder &reminder);
-    void updateReminderNextTrigger(const QString &id, const QDateTime &nextTrigger);
-    void initializeReminders();
-
     QTimer *checkTimer;
-    QMap<QString, QJsonObject> reminders;
     bool isPaused;
 
     QVector<Reminder> m_reminders;


### PR DESCRIPTION
## Summary
- clean up unused member function declarations in `ReminderManager`
- remove unused methods in `ReminderList`
- drop unused static members from `ReminderEdit`

## Testing
- `qmake` *(fails: command not found)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_684b946f7d248331bb5f89d47356d598