### PR TITLE
Remove unused ConfigManager functions

### DIFF
--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -64,65 +64,6 @@ void ConfigManager::setReminders(const QJsonArray &reminders)
     saveConfig();
 }
 
-void ConfigManager::addReminder(const QJsonObject &reminder)
-{
-    QString id = reminder["id"].toString();
-    QString name = reminder["name"].toString();
-    LOG_INFO(QString("添加新提醒: ID='%1', 名称='%2'").arg(id).arg(name));
-    
-    QJsonArray reminders = config[REMINDERS_KEY].toArray();
-    reminders.append(reminder);
-    config[REMINDERS_KEY] = reminders;
-    saveConfig();
-}
-
-void ConfigManager::updateReminder(const QString &id, const QJsonObject &reminder)
-{
-    LOG_INFO(QString("更新提醒: ID='%1'").arg(id));
-    QJsonArray reminders = config[REMINDERS_KEY].toArray();
-    bool found = false;
-    for (int i = 0; i < reminders.size(); ++i) {
-        QJsonObject obj = reminders[i].toObject();
-        if (obj["id"].toString() == id) {
-            reminders[i] = reminder;
-            found = true;
-            LOG_INFO(QString("找到并更新提醒: ID='%1', 新名称='%2'")
-                    .arg(id)
-                    .arg(reminder["name"].toString()));
-            break;
-        }
-    }
-    if (!found) {
-        LOG_WARNING(QString("未找到要更新的提醒: ID='%1'").arg(id));
-    }
-    config[REMINDERS_KEY] = reminders;
-    saveConfig();
-}
-
-void ConfigManager::deleteReminder(const QString &id)
-{
-    LOG_INFO(QString("删除提醒: ID='%1'").arg(id));
-    QJsonArray reminders = config[REMINDERS_KEY].toArray();
-    QJsonArray newReminders;
-    bool found = false;
-    for (const QJsonValue &value : reminders) {
-        QJsonObject obj = value.toObject();
-        if (obj["id"].toString() != id) {
-            newReminders.append(obj);
-        } else {
-            found = true;
-            LOG_INFO(QString("找到并删除提醒: ID='%1', 名称='%2'")
-                    .arg(id)
-                    .arg(obj["name"].toString()));
-        }
-    }
-    if (!found) {
-        LOG_WARNING(QString("未找到要删除的提醒: ID='%1'").arg(id));
-    }
-    config[REMINDERS_KEY] = newReminders;
-    saveConfig();
-}
-
 void ConfigManager::saveConfig()
 {
     QString path = getConfigPath();

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -22,9 +22,6 @@ public:
     void setPaused(bool paused);
     QJsonArray getReminders() const;
     void setReminders(const QJsonArray &reminders);
-    void addReminder(const QJsonObject &reminder);
-    void updateReminder(const QString &id, const QJsonObject &reminder);
-    void deleteReminder(const QString &id);
 
     void saveConfig();
     void loadConfig();

--- a/src/reminder.cpp
+++ b/src/reminder.cpp
@@ -1,5 +1,4 @@
 #include "reminder.h"
-#include <QJsonArray>
 #include <QUuid>
 #include "logger.h"
 
@@ -37,16 +36,6 @@ Reminder Reminder::fromJson(const QJsonObject &json)
     reminder.m_type = static_cast<Type>(json["type"].toInt());
     reminder.m_isEnabled = json["isEnabled"].toBool();
     reminder.m_nextTrigger = QDateTime::fromString(json["nextTrigger"].toString(), Qt::ISODate);
-
-    QJsonArray weekDaysArray = json["weekDays"].toArray();
-    for (const QJsonValue &value : weekDaysArray) {
-        reminder.m_weekDays.insert(value.toInt());
-    }
-
-    QJsonArray monthDaysArray = json["monthDays"].toArray();
-    for (const QJsonValue &value : monthDaysArray) {
-        reminder.m_monthDays.insert(value.toInt());
-    }
 
     LOG_INFO(QString("提醒反序列化完成: ID='%1', 类型=%2, 启用状态=%3")
              .arg(id)

--- a/src/reminder.h
+++ b/src/reminder.h
@@ -4,7 +4,6 @@
 #include <QString>
 #include <QDateTime>
 #include <QJsonObject>
-#include <QSet>
 #include "logger.h"
 
 class Reminder {
@@ -22,8 +21,6 @@ public:
     Type type() const { return m_type; }
     bool isEnabled() const { return m_isEnabled; }
     QDateTime nextTrigger() const { return m_nextTrigger; }
-    QSet<int> weekDays() const { return m_weekDays; }
-    QSet<int> monthDays() const { return m_monthDays; }
     QString id() const { return m_id; }
     QString title() const { return m_name; }
 
@@ -32,8 +29,6 @@ public:
     void setType(Type type) { m_type = type; }
     void setEnabled(bool enabled) { m_isEnabled = enabled; }
     void setNextTrigger(const QDateTime &trigger) { m_nextTrigger = trigger; }
-    void setWeekDays(const QSet<int> &days) { m_weekDays = days; }
-    void setMonthDays(const QSet<int> &days) { m_monthDays = days; }
     void setId(const QString &id) { m_id = id; }
 
     // JSON serialization
@@ -58,8 +53,6 @@ private:
     Type m_type = Type::Once;
     bool m_isEnabled = true;
     QDateTime m_nextTrigger;
-    QSet<int> m_weekDays;
-    QSet<int> m_monthDays;
     QString m_id;
 };
 


### PR DESCRIPTION
## Summary
- remove `addReminder`, `updateReminder`, and `deleteReminder` from `ConfigManager`
- drop the unused implementations
- eliminate defunct repeat day fields from `Reminder`

## Testing
- `qmake` *(fails: command not found)*
- `make` *(fails: No makefile)*

------
https://chatgpt.com/codex/tasks/task_e_684bb9333a908331856d12e0d493dc2e