### PR TITLE
Remove unused reminder features

### DIFF
--- a/src/reminder.cpp
+++ b/src/reminder.cpp
@@ -2,13 +2,6 @@
 #include <QUuid>
 #include "logger.h"
 
-Reminder::Reminder(const QString &name, Type type)
-    : m_name(name)
-    , m_type(type)
-    , m_isEnabled(true)
-{
-    LOG_INFO(QString("创建新提醒: 名称='%1', ID='%2'").arg(name).arg(m_id));
-}
 
 QJsonObject Reminder::toJson() const
 {
@@ -17,7 +10,6 @@ QJsonObject Reminder::toJson() const
     json["id"] = m_id;
     json["name"] = m_name;
     json["type"] = static_cast<int>(m_type);
-    json["isEnabled"] = m_isEnabled;
     json["nextTrigger"] = m_nextTrigger.toString(Qt::ISODate);
 
     LOG_INFO(QString("提醒序列化完成: ID='%1'").arg(m_id));
@@ -34,12 +26,10 @@ Reminder Reminder::fromJson(const QJsonObject &json)
     reminder.m_id = id;
     reminder.m_name = name;
     reminder.m_type = static_cast<Type>(json["type"].toInt());
-    reminder.m_isEnabled = json["isEnabled"].toBool();
     reminder.m_nextTrigger = QDateTime::fromString(json["nextTrigger"].toString(), Qt::ISODate);
 
-    LOG_INFO(QString("提醒反序列化完成: ID='%1', 类型=%2, 启用状态=%3")
+    LOG_INFO(QString("提醒反序列化完成: ID='%1', 类型=%2")
              .arg(id)
-             .arg(static_cast<int>(reminder.m_type))
-             .arg(reminder.m_isEnabled));
+             .arg(static_cast<int>(reminder.m_type)));
     return reminder;
 }

--- a/src/reminder.h
+++ b/src/reminder.h
@@ -14,20 +14,16 @@ public:
     };
 
     Reminder() = default;
-    Reminder(const QString &name, Type type = Type::Once);
 
     // Getters
     QString name() const { return m_name; }
     Type type() const { return m_type; }
-    bool isEnabled() const { return m_isEnabled; }
     QDateTime nextTrigger() const { return m_nextTrigger; }
     QString id() const { return m_id; }
-    QString title() const { return m_name; }
 
     // Setters
     void setName(const QString &name) { m_name = name; }
     void setType(Type type) { m_type = type; }
-    void setEnabled(bool enabled) { m_isEnabled = enabled; }
     void setNextTrigger(const QDateTime &trigger) { m_nextTrigger = trigger; }
     void setId(const QString &id) { m_id = id; }
 
@@ -39,7 +35,6 @@ public:
     bool operator==(const Reminder &other) const {
         return m_name == other.m_name &&
                m_type == other.m_type &&
-               m_isEnabled == other.m_isEnabled &&
                m_nextTrigger == other.m_nextTrigger &&
                m_id == other.m_id;
     }
@@ -51,7 +46,6 @@ public:
 private:
     QString m_name;
     Type m_type = Type::Once;
-    bool m_isEnabled = true;
     QDateTime m_nextTrigger;
     QString m_id;
 };

--- a/src/reminderedit.cpp
+++ b/src/reminderedit.cpp
@@ -27,7 +27,6 @@ ReminderEdit::ReminderEdit(QWidget *parent)
     QDateTime now = QDateTime::currentDateTime();
     ui->dateTimeEdit->setDateTime(now);
     ui->timeEdit->setTime(now.time());
-    reminderData["isEnabled"] = true;
     reminderData["type"] = static_cast<int>(ReminderType::OneTime);
     reminderData["nextTrigger"] = now.toString(Qt::ISODate);
     // 初始化控件显示
@@ -52,7 +51,6 @@ void ReminderEdit::reset()
     
     // 重置reminderData
     reminderData = QJsonObject();
-    reminderData["isEnabled"] = true;
     reminderData["type"] = static_cast<int>(ReminderType::OneTime);
     reminderData["nextTrigger"] = now.toString(Qt::ISODate);
     

--- a/src/reminderlist.cpp
+++ b/src/reminderlist.cpp
@@ -19,8 +19,7 @@
 enum ColumnIndex {
     Name = 0,
     Type = 1,
-    Status = 2,
-    NextTrigger = 3
+    NextTrigger = 2
 };
 
 ReminderList::ReminderList(QWidget *parent)
@@ -131,7 +130,6 @@ void ReminderList::addReminderToModel(const QJsonObject &reminder)
     Reminder newReminder;
     newReminder.setName(reminder["name"].toString());
     newReminder.setType(static_cast<Reminder::Type>(reminder["type"].toInt()));
-    newReminder.setEnabled(reminder["isEnabled"].toBool());
     newReminder.setNextTrigger(QDateTime::fromString(reminder["nextTrigger"].toString(), Qt::ISODate));
     
     model->addReminder(newReminder);
@@ -147,14 +145,12 @@ void ReminderList::updateReminderInModel(const QJsonObject &reminder)
             Reminder updatedReminder;
             updatedReminder.setName(reminder["name"].toString());
             updatedReminder.setType(static_cast<Reminder::Type>(reminder["type"].toInt()));
-            updatedReminder.setEnabled(reminder["isEnabled"].toBool());
             updatedReminder.setNextTrigger(QDateTime::fromString(reminder["nextTrigger"].toString(), Qt::ISODate));
             
             model->updateReminder(i, updatedReminder);
-            LOG_INFO(QString("提醒更新成功: 名称='%1', 类型=%2, 启用状态=%3")
+            LOG_INFO(QString("提醒更新成功: 名称='%1', 类型=%2")
                     .arg(updatedReminder.name())
-                    .arg(static_cast<int>(updatedReminder.type()))
-                    .arg(updatedReminder.isEnabled()));
+                    .arg(static_cast<int>(updatedReminder.type())));
             break;
         }
     }
@@ -223,15 +219,6 @@ void ReminderList::deleteReminder(const QModelIndex &index)
     }
 }
 
-void ReminderList::toggleReminder(const QModelIndex &index)
-{
-    QModelIndex sourceIndex = proxyModel->mapToSource(index);
-    Reminder reminder = model->getReminder(sourceIndex.row());
-    LOG_INFO(QString("切换提醒状态: 名称='%1', 当前状态=%2")
-             .arg(reminder.name())
-             .arg(reminder.isEnabled()));
-    model->toggleReminder(sourceIndex.row());
-}
 
 void ReminderList::refreshList()
 {

--- a/src/reminderlist.h
+++ b/src/reminderlist.h
@@ -27,7 +27,6 @@ public:
     void addNewReminder();
     void editReminder(const QModelIndex &index);
     void deleteReminder(const QModelIndex &index);
-    void toggleReminder(const QModelIndex &index);
     void refreshList();
     void searchReminders(const QString &text);
     QJsonObject getReminderData(const QString &name) const;

--- a/src/remindermanager.cpp
+++ b/src/remindermanager.cpp
@@ -167,11 +167,6 @@ void ReminderManager::calculateNextTrigger(Reminder &reminder)
 
 bool ReminderManager::shouldTrigger(const Reminder &reminder) const
 {
-    if (!reminder.isEnabled()) {
-        LOG_DEBUG(QString("检查提醒 [%1] 是否触发: 提醒已禁用，不触发")
-            .arg(reminder.id()));
-        return false;
-    }
     
     QDateTime currentTime = QDateTime::currentDateTime();
     QDateTime nextTrigger = reminder.nextTrigger();
@@ -208,7 +203,7 @@ void ReminderManager::showNotification(const Reminder &reminder)
     }
 
     QString message = tr("提醒: %1\n类型: %2\n时间: %3")
-        .arg(reminder.title())
+        .arg(reminder.name())
         .arg(typeStr)
         .arg(reminder.nextTrigger().toString("yyyy-MM-dd HH:mm:ss"));
 
@@ -231,12 +226,3 @@ QJsonArray ReminderManager::getRemindersJson() const
     return array;
 }
 
-void ReminderManager::toggleReminder(int index)
-{
-    if (index >= 0 && index < m_reminders.size()) {
-        Reminder &reminder = m_reminders[index];
-        reminder.setEnabled(!reminder.isEnabled());
-        saveReminders();
-        emit remindersChanged();
-    }
-}

--- a/src/remindermanager.h
+++ b/src/remindermanager.h
@@ -24,7 +24,6 @@ public:
     void updateReminder(int index, const Reminder &reminder);
     void deleteReminder(int index);
     QVector<Reminder> getReminders() const;
-    void toggleReminder(int index);
 
     void pauseAll();
     void resumeAll();

--- a/src/remindertablemodel.cpp
+++ b/src/remindertablemodel.cpp
@@ -19,7 +19,7 @@ int ReminderTableModel::columnCount(const QModelIndex &parent) const
 {
     if (parent.isValid())
         return 0;
-    return 4; 
+    return 3;
 }
 
 QVariant ReminderTableModel::data(const QModelIndex &index, int role) const
@@ -40,8 +40,6 @@ QVariant ReminderTableModel::data(const QModelIndex &index, int role) const
             default: return "未知";
             }
         case 2:
-            return reminder.isEnabled() ? "启用" : "禁用";
-        case 3:
             return reminder.nextTrigger().toString("yyyy-MM-dd hh:mm:ss");
         }
     }
@@ -57,8 +55,7 @@ QVariant ReminderTableModel::headerData(int section, Qt::Orientation orientation
         switch (section) {
         case 0: return "名称";
         case 1: return "类型";
-        case 2: return "状态";
-        case 3: return "下次触发时间";
+        case 2: return "下次触发时间";
         }
     }
     return QVariant();
@@ -84,9 +81,6 @@ bool ReminderTableModel::setData(const QModelIndex &index, const QVariant &value
     case 0:
         reminder.setName(value.toString());
         break;
-    case 2:
-        reminder.setEnabled(value.toBool());
-        break;
     default:
         return false;
     }
@@ -101,7 +95,7 @@ Qt::ItemFlags ReminderTableModel::flags(const QModelIndex &index) const
         return Qt::NoItemFlags;
 
     Qt::ItemFlags flags = QAbstractTableModel::flags(index);
-    if (index.column() == 0 || index.column() == 2)
+    if (index.column() == 0)
         flags |= Qt::ItemIsEditable;
     return flags;
 }
@@ -163,15 +157,6 @@ QJsonArray ReminderTableModel::saveToJson() const
     return array;
 }
 
-void ReminderTableModel::toggleReminder(int row)
-{
-    if (row < 0 || row >= m_reminders.size())
-        return;
-
-    Reminder &reminder = m_reminders[row];
-    reminder.setEnabled(!reminder.isEnabled());
-    emit dataChanged(index(row, 2), index(row, 2));
-}
 
 void ReminderTableModel::search(const QString &text)
 {

--- a/src/remindertablemodel.h
+++ b/src/remindertablemodel.h
@@ -31,9 +31,6 @@ public:
     void loadFromJson(const QList<Reminder> &reminders);
     QJsonArray saveToJson() const;
 
-    // 提醒状态管理
-    void toggleReminder(int row);
-
     // 搜索功能
     void search(const QString &text);
 


### PR DESCRIPTION
## Summary
- drop `isEnabled` flag and `title()` from `Reminder`
- delete unused constructor from `Reminder`
- simplify reminder JSON serialization
- remove toggle functionality and status column
- adjust models and UI logic for the simplified reminder data

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bbe7f73bc8331befc9bfb52d6560b