### PR TITLE
Move ID generation logic from dialog to manager

### DIFF
--- a/src/reminderedit.cpp
+++ b/src/reminderedit.cpp
@@ -1,7 +1,6 @@
 #include "reminderedit.h"
 #include "./ui_reminderedit.h"
 #include <QMessageBox>
-#include <QUuid>
 #include <QDateTime>
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -130,16 +129,9 @@ void ReminderEdit::onOkClicked()
     if (validateInput()) {
         QString name = ui->nameEdit->text().trimmed();
         reminderData["name"] = name;
-        
-        // 如果是新建提醒（没有ID），则生成新的ID
-        if (!reminderData.contains("id") || reminderData["id"].toString().isEmpty()) {
-            QString newId = QUuid::createUuid().toString(QUuid::WithoutBraces);
-            reminderData["id"] = newId;
-            LOG_INFO(QString("新建提醒，生成ID: %1").arg(newId));
-        }
-        
+
         LOG_INFO(QString("保存提醒: ID='%1', 名称='%2', 类型='%3'")
-                 .arg(reminderData["id"].toString())
+                 .arg(reminderData.value("id").toString())
                  .arg(name)
                  .arg(reminderData["type"].toString()));
         accept();

--- a/src/reminderlist.h
+++ b/src/reminderlist.h
@@ -43,8 +43,8 @@ public slots:
 private:
     void setupConnections();
     void setupModel();
-    void addReminderToModel(const QJsonObject &reminder);
-    void updateReminderInModel(const QJsonObject &reminder);
+    void addReminderToModel(const Reminder &reminder);
+    void updateReminderInModel(const Reminder &reminder);
 
     Ui::ReminderList *ui;
     ReminderManager *reminderManager;

--- a/src/remindermanager.cpp
+++ b/src/remindermanager.cpp
@@ -57,11 +57,19 @@ void ReminderManager::loadReminders()
     LOG_INFO(QString("共加载 %1 个提醒").arg(m_reminders.size()));
 }
 
-void ReminderManager::addReminder(const Reminder &reminder)
+Reminder ReminderManager::addReminder(const Reminder &reminder)
 {
-    m_reminders.append(reminder);
+    Reminder newReminder = reminder;
+    if (newReminder.id().isEmpty()) {
+        QString id = QUuid::createUuid().toString(QUuid::WithoutBraces);
+        newReminder.setId(id);
+        LOG_INFO(QString("生成新的提醒ID: %1").arg(id));
+    }
+
+    m_reminders.append(newReminder);
     saveReminders();
     emit remindersChanged();
+    return newReminder;
 }
 
 void ReminderManager::updateReminder(int index, const Reminder &reminder)

--- a/src/remindermanager.h
+++ b/src/remindermanager.h
@@ -20,7 +20,7 @@ public:
     explicit ReminderManager(QObject *parent = nullptr);
     ~ReminderManager();
 
-    void addReminder(const Reminder &reminder);
+    Reminder addReminder(const Reminder &reminder);
     void updateReminder(int index, const Reminder &reminder);
     void deleteReminder(int index);
     QVector<Reminder> getReminders() const;


### PR DESCRIPTION
## Summary
- generate new reminder IDs in `ReminderManager`
- keep reminder IDs in the table model when adding and editing
- update reminder list logic to match reminders by ID
- adjust dialog to only gather input without creating IDs

## Testing
- `qmake` *(fails: command not found)*
- `make` *(fails: no makefile)*

------
https://chatgpt.com/codex/tasks/task_e_684bd32a58508331967d6f3ebcebdcb7