### PR TITLE
Refactor reminder edit workflow

### DIFF
--- a/src/reminderedit.h
+++ b/src/reminderedit.h
@@ -19,9 +19,9 @@ public:
     explicit ReminderEdit(QWidget *parent = nullptr);
     ~ReminderEdit();
 
-    void loadReminderData(const QJsonObject &reminder);
+    void prepareEditReminder(const QJsonObject &reminder);
+    void prepareNewReminder();
     QJsonObject getReminderData() const;
-    void reset();
 
 private slots:
     void onTypeChanged(int index);

--- a/src/reminderlist.cpp
+++ b/src/reminderlist.cpp
@@ -107,7 +107,7 @@ QJsonArray ReminderList::getReminders() const
 void ReminderList::addNewReminder()
 {
     LOG_INFO("添加新提醒");
-    editDialog->reset(); 
+    editDialog->prepareNewReminder();
     if (editDialog->exec() == QDialog::Accepted) {
         QJsonObject reminder = editDialog->getReminderData();
         if (reminderManager) {
@@ -163,7 +163,7 @@ void ReminderList::editReminder(const QModelIndex &index)
     LOG_INFO(QString("编辑提醒: 名称='%1'").arg(reminder.name()));
     
     QJsonObject reminderData = reminder.toJson();
-    editDialog->loadReminderData(reminderData);
+    editDialog->prepareEditReminder(reminderData);
     if (editDialog->exec() == QDialog::Accepted) {
         QJsonObject updatedData = editDialog->getReminderData();
         updateReminderInModel(updatedData);


### PR DESCRIPTION
## Summary
- refactor `ReminderEdit` new/edit initialization
- move UUID generation to new reminder prep
- update usages in `ReminderList`

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bdb2bc98c83319d903228a55fbd01