### PR TITLE
Move unused API methods to private

### DIFF
--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -23,14 +23,13 @@ public:
     QJsonArray getReminders() const;
     void setReminders(const QJsonArray &reminders);
 
-    void saveConfig();
-    void loadConfig();
-
 private:
     explicit ConfigManager(QObject *parent = nullptr);
     ~ConfigManager();
     void init();
     void initDefaultConfig();
+    void saveConfig();
+    void loadConfig();
     QString getConfigPath() const;
 
     QJsonObject config;

--- a/src/reminderlist.h
+++ b/src/reminderlist.h
@@ -22,16 +22,9 @@ public:
     ~ReminderList();
 
     void setReminderManager(ReminderManager *manager);
-    void loadReminders(const QList<Reminder> &reminders);
-    QJsonArray getReminders() const;
-    void addNewReminder();
-    void editReminder(const QModelIndex &index);
-    void deleteReminder(const QModelIndex &index);
-    void refreshList();
-    void searchReminders(const QString &text);
-    QJsonObject getReminderData(const QString &name) const;
 
-public slots:
+
+private slots:
     void onReminderTriggered(const Reminder &reminder);
     void onAddClicked();
     void onEditClicked();
@@ -43,6 +36,14 @@ public slots:
 private:
     void setupConnections();
     void setupModel();
+    void loadReminders(const QList<Reminder> &reminders);
+    QJsonArray getReminders() const;
+    void addNewReminder();
+    void editReminder(const QModelIndex &index);
+    void deleteReminder(const QModelIndex &index);
+    void refreshList();
+    void searchReminders(const QString &text);
+    QJsonObject getReminderData(const QString &name) const;
     void addReminderToModel(const QJsonObject &reminder);
     void updateReminderInModel(const QJsonObject &reminder);
 

--- a/src/remindermanager.h
+++ b/src/remindermanager.h
@@ -27,9 +27,7 @@ public:
 
     void pauseAll();
     void resumeAll();
-    QJsonArray getRemindersJson() const;
     void saveReminders();
-    void loadReminders();
 
 signals:
     void remindersChanged();
@@ -44,6 +42,8 @@ private:
     void calculateNextTrigger(Reminder &reminder);
     bool shouldTrigger(const Reminder &reminder) const;
     void showNotification(const Reminder &reminder);
+    QJsonArray getRemindersJson() const;
+    void loadReminders();
     QTimer *checkTimer;
     bool isPaused;
 

--- a/src/remindertablemodel.h
+++ b/src/remindertablemodel.h
@@ -25,7 +25,6 @@ public:
     void updateReminder(int row, const Reminder &reminder);
     void removeReminder(int row);
     Reminder getReminder(int row) const;
-    QVector<Reminder> getAllReminders() const;
 
     // JSON序列化
     void loadFromJson(const QList<Reminder> &reminders);
@@ -36,6 +35,7 @@ public:
 
 private:
     void updateFilteredList();
+    QVector<Reminder> getAllReminders() const;
 
     QVector<Reminder> m_reminders;
     QVector<Reminder> m_filteredReminders;


### PR DESCRIPTION
## Summary
- restrict config loading and saving to private
- hide ReminderList helper methods
- hide ReminderManager helper methods
- hide unused getAllReminders method

## Testing
- `qmake -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684beb3219148331bc6fc1d0831dceaf