### PR TITLE
Fix missing UI headers

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1,5 +1,5 @@
 #include "mainwindow.h"
-#include "./ui_mainwindow.h"
+#include "ui_mainwindow.h"
 #include <QMessageBox>
 #include <QSettings>
 #include <QVBoxLayout>

--- a/src/reminderedit.cpp
+++ b/src/reminderedit.cpp
@@ -1,5 +1,5 @@
 #include "reminderedit.h"
-#include "./ui_reminderedit.h"
+#include "ui_reminderedit.h"
 #include <QMessageBox>
 #include <QUuid>
 #include <QDateTime>
@@ -42,7 +42,8 @@ void ReminderEdit::prepareNewReminder()
     ui->timeEdit->setTime(now.time());
     ui->typeCombo->setCurrentIndex(0);
 
-    reminderData.clear();
+    // QJsonObject does not have a clear() method, so assign a new empty object
+    reminderData = QJsonObject();
     reminderData["id"] = QUuid::createUuid().toString(QUuid::WithoutBraces);
     reminderData["type"] = static_cast<int>(ReminderType::OneTime);
     reminderData["nextTrigger"] = now.toString(Qt::ISODate);

--- a/src/reminderlist.cpp
+++ b/src/reminderlist.cpp
@@ -1,5 +1,5 @@
 #include "reminderlist.h"
-#include "./ui_reminderlist.h"
+#include "ui_reminderlist.h"
 #include <QHeaderView>
 #include <QMessageBox>
 #include <QJsonDocument>


### PR DESCRIPTION
## Summary
- fix include paths so that qmake finds generated headers
- replace use of non-existent QJsonObject::clear()

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bed2e6d088331b84235abe0a0a6a2