### PR TITLE
Refactor ReminderEdit to use Reminder objects

### DIFF
--- a/src/reminderedit.h
+++ b/src/reminderedit.h
@@ -2,8 +2,7 @@
 #define REMINDEREDIT_H
 
 #include <QDialog>
-#include <QJsonObject>
-#include <QJsonArray>
+#include "reminder.h"
 #include <QStringList>
 #include <QDateTime>
 
@@ -19,9 +18,9 @@ public:
     explicit ReminderEdit(QWidget *parent = nullptr);
     ~ReminderEdit();
 
-    void prepareEditReminder(const QJsonObject &reminder);
+    void prepareEditReminder(const Reminder &reminder);
     void prepareNewReminder();
-    QJsonObject getReminderData() const;
+    Reminder getReminder() const;
 
 private slots:
     void onTypeChanged(int index);
@@ -37,8 +36,7 @@ private:
     void updateNextTriggerTime();
 
     Ui::ReminderEdit *ui;
-    QJsonObject reminderData;
-    QDateTime nextTriggerTime;
+    Reminder m_reminder;
 
 };
 

--- a/src/reminderlist.h
+++ b/src/reminderlist.h
@@ -44,8 +44,8 @@ private:
     void refreshList();
     void searchReminders(const QString &text);
     QJsonObject getReminderData(const QString &name) const;
-    void addReminderToModel(const QJsonObject &reminder);
-    void updateReminderInModel(const QJsonObject &reminder);
+    void addReminderToModel(const Reminder &reminder);
+    void updateReminderInModel(const Reminder &reminder);
 
     Ui::ReminderList *ui;
     ReminderManager *reminderManager;


### PR DESCRIPTION
## Summary
- handle Reminder objects directly in ReminderEdit
- update ReminderList to pass Reminder objects without JSON conversion

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c3ce442ac8331aa39300579431ec1