### PR TITLE
Add message label to notification popup

### DIFF
--- a/src/notificationPopup.ui
+++ b/src/notificationPopup.ui
@@ -16,7 +16,7 @@
     <height>80</height>
    </size>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,1">
    <item>
     <layout class="QHBoxLayout" name="topLayout">
      <item>
@@ -46,6 +46,22 @@
       </widget>
      </item>
     </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="messageLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>提醒内容</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
    <item>
     <spacer name="verticalSpacer">


### PR DESCRIPTION
## Summary
- allow notifications to display a multi-line message
- expand popup height automatically with the new label

## Testing
- `qmake -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d082df730833188f2fcde9580de5f