### PR TITLE
Add priority icons using Qt standard icons

### DIFF
--- a/src/notificationPopup.cpp
+++ b/src/notificationPopup.cpp
@@ -2,6 +2,7 @@
 #include <QScreen>
 #include <QApplication>
 #include <QPushButton>
+#include <QStyle>
 #include "NotificationPopup.h"
 #include <QHBoxLayout>
 #include <QVBoxLayout>
@@ -9,7 +10,7 @@
 #include <QScopedPointer>
 
 NotificationPopup::NotificationPopup(const QString &title,
-                                     const QIcon &icon,
+                                     Priority priority,
                                      int timeoutMs,
                                      QWidget *parent)
   : QWidget(nullptr, Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint),
@@ -22,6 +23,22 @@ NotificationPopup::NotificationPopup(const QString &title,
 
     // 设置标题
     ui->titleLabel->setText(title);
+    // 根据优先级设置图标
+    QStyle *style = QApplication::style();
+    QIcon icon;
+    switch (priority) {
+    case Priority::Warning:
+        icon = style->standardIcon(QStyle::SP_MessageBoxWarning);
+        break;
+    case Priority::Critical:
+        icon = style->standardIcon(QStyle::SP_MessageBoxCritical);
+        break;
+    case Priority::Information:
+    default:
+        icon = style->standardIcon(QStyle::SP_MessageBoxInformation);
+        break;
+    }
+    ui->iconLabel->setPixmap(icon.pixmap(24, 24));
     // 关闭按钮
     connect(ui->closeButton, &QPushButton::clicked, this, &NotificationPopup::close);
     // 动画和定时器逻辑保持不变

--- a/src/notificationPopup.h
+++ b/src/notificationPopup.h
@@ -12,8 +12,13 @@
 class NotificationPopup : public QWidget {
     Q_OBJECT
 public:
+    enum class Priority {
+        Information,
+        Warning,
+        Critical
+    };
     NotificationPopup(const QString &title,
-                      const QIcon &icon = {},
+                      Priority priority = Priority::Information,
                       int timeoutMs = 5000,
                       QWidget *parent = nullptr);
     

--- a/src/notificationPopup.ui
+++ b/src/notificationPopup.ui
@@ -20,6 +20,9 @@
    <item>
     <layout class="QHBoxLayout" name="topLayout">
      <item>
+      <widget class="QLabel" name="iconLabel"/>
+     </item>
+     <item>
       <widget class="QLabel" name="titleLabel">
        <property name="text">
         <string>标题</string>

--- a/src/remindermanager.cpp
+++ b/src/remindermanager.cpp
@@ -185,7 +185,7 @@ void ReminderManager::showNotification(const Reminder &reminder)
 {
     NotificationPopup *popup = new NotificationPopup(
         reminder.name(),
-        QIcon(":/img/tray_icon.png"));
+        NotificationPopup::Priority::Information);
     popup->show();
 }
 


### PR DESCRIPTION
## Summary
- introduce `Priority` enum to `NotificationPopup`
- display built-in Qt icons based on `Priority`
- add icon label to notification popup UI
- use the new `Priority` enum in `ReminderManager`

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d08332b6883318a2cb087deb4e3de