### PR TITLE
Add message and priority to NotificationPopup

### DIFF
--- a/src/notificationPopup.cpp
+++ b/src/notificationPopup.cpp
@@ -7,13 +7,18 @@
 #include <QVBoxLayout>
 #include "ui_notificationPopup.h"
 #include <QScopedPointer>
+#include <QStyle>
 
 NotificationPopup::NotificationPopup(const QString &title,
+                                     const QString &message,
+                                     Priority priority,
                                      const QIcon &icon,
                                      int timeoutMs,
                                      QWidget *parent)
   : QWidget(nullptr, Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint),
-    ui(new Ui::NotificationPopup)
+    ui(new Ui::NotificationPopup),
+    m_message(message),
+    m_priority(priority)
 {
     ui->setupUi(this);
     setAttribute(Qt::WA_ShowWithoutActivating);
@@ -22,6 +27,29 @@ NotificationPopup::NotificationPopup(const QString &title,
 
     // 设置标题
     ui->titleLabel->setText(title);
+    if (message.isEmpty()) {
+        ui->messageLabel->setText(tr("你有新的提醒"));
+    } else {
+        ui->messageLabel->setText(message);
+    }
+
+    QIcon finalIcon = icon;
+    if (finalIcon.isNull()) {
+        QStyle::StandardPixmap sp = QStyle::SP_MessageBoxInformation;
+        switch (priority) {
+        case Priority::Low:
+            sp = QStyle::SP_MessageBoxInformation;
+            break;
+        case Priority::Medium:
+            sp = QStyle::SP_MessageBoxWarning;
+            break;
+        case Priority::High:
+            sp = QStyle::SP_MessageBoxCritical;
+            break;
+        }
+        finalIcon = style()->standardIcon(sp);
+    }
+    ui->priorityLabel->setPixmap(finalIcon.pixmap(24, 24));
     // 关闭按钮
     connect(ui->closeButton, &QPushButton::clicked, this, &NotificationPopup::close);
     // 动画和定时器逻辑保持不变
@@ -50,6 +78,14 @@ NotificationPopup::NotificationPopup(const QString &title,
         border-radius: 10px;
       }
     )");
+}
+
+NotificationPopup::NotificationPopup(const QString &title,
+                                     const QIcon &icon,
+                                     int timeoutMs,
+                                     QWidget *parent)
+    : NotificationPopup(title, {}, Priority::Medium, icon, timeoutMs, parent)
+{
 }
 
 

--- a/src/notificationPopup.h
+++ b/src/notificationPopup.h
@@ -12,8 +12,22 @@
 class NotificationPopup : public QWidget {
     Q_OBJECT
 public:
+
+    enum class Priority {
+        Low,
+        Medium,
+        High
+    };
+
     NotificationPopup(const QString &title,
+                      const QString &message = {},
+                      Priority priority = Priority::Medium,
                       const QIcon &icon = {},
+                      int timeoutMs = 5000,
+                      QWidget *parent = nullptr);
+
+    NotificationPopup(const QString &title,
+                      const QIcon &icon,
                       int timeoutMs = 5000,
                       QWidget *parent = nullptr);
     
@@ -23,4 +37,6 @@ private:
     QScopedPointer<Ui::NotificationPopup> ui;
     QPropertyAnimation *fadeIn, *fadeOut;
     QTimer *closeTimer;
+    QString m_message;
+    Priority m_priority = Priority::Medium;
 };

--- a/src/notificationPopup.ui
+++ b/src/notificationPopup.ui
@@ -20,14 +20,41 @@
    <item>
     <layout class="QHBoxLayout" name="topLayout">
      <item>
-      <widget class="QLabel" name="titleLabel">
-       <property name="text">
-        <string>标题</string>
+      <widget class="QLabel" name="priorityLabel">
+       <property name="minimumSize">
+        <size>
+         <width>24</width>
+         <height>24</height>
+        </size>
        </property>
        <property name="alignment">
-        <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+        <set>Qt::AlignmentFlag::AlignCenter</set>
        </property>
       </widget>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="textLayout">
+       <item>
+        <widget class="QLabel" name="titleLabel">
+         <property name="text">
+          <string>标题</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="messageLabel">
+         <property name="text">
+          <string></string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
      <item>
       <widget class="QPushButton" name="closeButton">


### PR DESCRIPTION
## Summary
- extend `NotificationPopup` with Priority enum and message support
- show appropriate icon and default text when message not supplied
- update UI with new labels for priority icon and message

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d08181a008331a132588ed58e55ca