### PR TITLE
Add message and priority support to notification popup

### DIFF
--- a/src/notificationPopup.cpp
+++ b/src/notificationPopup.cpp
@@ -10,35 +10,40 @@
 #include <QScopedPointer>
 
 NotificationPopup::NotificationPopup(const QString &title,
+                                     const QString &message,
                                      Priority priority,
                                      int timeoutMs,
                                      QWidget *parent)
   : QWidget(nullptr, Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint),
-    ui(new Ui::NotificationPopup)
+    ui(new Ui::NotificationPopup),
+    m_message(message),
+    m_priority(priority)
 {
     ui->setupUi(this);
     setAttribute(Qt::WA_ShowWithoutActivating);
     setAttribute(Qt::WA_StyledBackground);
     setAutoFillBackground(true);
 
-    // 设置标题
+    // set title and message
     ui->titleLabel->setText(title);
-    // 根据优先级设置图标
+    ui->messageLabel->setText(m_message.isEmpty() ? tr("Notification") : m_message);
+
+    // choose icon based on priority
     QStyle *style = QApplication::style();
     QIcon icon;
-    switch (priority) {
-    case Priority::Warning:
-        icon = style->standardIcon(QStyle::SP_MessageBoxWarning);
-        break;
-    case Priority::Critical:
-        icon = style->standardIcon(QStyle::SP_MessageBoxCritical);
-        break;
-    case Priority::Information:
-    default:
+    switch (m_priority) {
+    case Priority::Low:
         icon = style->standardIcon(QStyle::SP_MessageBoxInformation);
         break;
+    case Priority::High:
+        icon = style->standardIcon(QStyle::SP_MessageBoxCritical);
+        break;
+    case Priority::Medium:
+    default:
+        icon = style->standardIcon(QStyle::SP_MessageBoxWarning);
+        break;
     }
-    ui->iconLabel->setPixmap(icon.pixmap(24, 24));
+    ui->priorityLabel->setPixmap(icon.pixmap(24, 24));
     // 关闭按钮
     connect(ui->closeButton, &QPushButton::clicked, this, &NotificationPopup::close);
     // 动画和定时器逻辑保持不变

--- a/src/notificationPopup.h
+++ b/src/notificationPopup.h
@@ -12,13 +12,10 @@
 class NotificationPopup : public QWidget {
     Q_OBJECT
 public:
-    enum class Priority {
-        Information,
-        Warning,
-        Critical
-    };
+    enum Priority { Low, Medium, High };
     NotificationPopup(const QString &title,
-                      Priority priority = Priority::Information,
+                      const QString &message = {},
+                      Priority priority = Priority::Medium,
                       int timeoutMs = 5000,
                       QWidget *parent = nullptr);
     
@@ -28,4 +25,6 @@ private:
     QScopedPointer<Ui::NotificationPopup> ui;
     QPropertyAnimation *fadeIn, *fadeOut;
     QTimer *closeTimer;
+    QString m_message;
+    Priority m_priority;
 };

--- a/src/notificationPopup.ui
+++ b/src/notificationPopup.ui
@@ -16,12 +16,12 @@
     <height>80</height>
    </size>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,1">
+  <layout class="QHBoxLayout" name="horizontalLayout">
    <item>
-    <layout class="QHBoxLayout" name="topLayout">
-     <item>
-      <widget class="QLabel" name="iconLabel"/>
-     </item>
+    <widget class="QLabel" name="priorityLabel"/>
+   </item>
+   <item>
+    <layout class="QVBoxLayout" name="textLayout">
      <item>
       <widget class="QLabel" name="titleLabel">
        <property name="text">
@@ -33,51 +33,32 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="closeButton">
-       <property name="styleSheet">
-        <string>QPushButton { color: white; background: transparent; border: none; font-size: 18px; } QPushButton:hover { color: #ff6666; }</string>
-       </property>
+      <widget class="QLabel" name="messageLabel">
        <property name="text">
-        <string>×</string>
+        <string>提醒内容</string>
        </property>
-       <property name="fixedSize" stdset="0">
-        <size>
-         <width>24</width>
-         <height>24</height>
-        </size>
+       <property name="wordWrap">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
     </layout>
    </item>
    <item>
-    <widget class="QLabel" name="messageLabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+    <widget class="QPushButton" name="closeButton">
+     <property name="styleSheet">
+      <string>QPushButton { color: white; background: transparent; border: none; font-size: 18px; } QPushButton:hover { color: #ff6666; }</string>
      </property>
      <property name="text">
-      <string>提醒内容</string>
+      <string>×</string>
      </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Orientation::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
+     <property name="fixedSize" stdset="0">
       <size>
-       <width>20</width>
-       <height>40</height>
+       <width>24</width>
+       <height>24</height>
       </size>
      </property>
-    </spacer>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/remindermanager.cpp
+++ b/src/remindermanager.cpp
@@ -183,9 +183,7 @@ bool ReminderManager::shouldTrigger(const Reminder &reminder) const
 
 void ReminderManager::showNotification(const Reminder &reminder)
 {
-    NotificationPopup *popup = new NotificationPopup(
-        reminder.name(),
-        NotificationPopup::Priority::Information);
+    NotificationPopup *popup = new NotificationPopup(reminder.name());
     popup->show();
 }
 


### PR DESCRIPTION
## Summary
- allow notification popup to show a message and priority icon
- select icon based on Low/Medium/High priority
- update reminder manager to use new popup defaults
- restructure popup UI layout

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d38141e8883319011a177198023bc