### PR TITLE
Add completed reminders view

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3,6 +3,7 @@
 #include <QMessageBox>
 #include <QSettings>
 #include <QVBoxLayout>
+#include <QTabWidget>
 #include <QCloseEvent>
 #include "configmanager.h"
 
@@ -26,6 +27,7 @@ MainWindow::MainWindow(QWidget *parent)
     
     // 连接提醒列表和提醒管理器
     reminderList->setReminderManager(reminderManager);
+    completedList->setReminderManager(reminderManager);
     
     // 创建系统托盘图标
     createTrayIcon();
@@ -56,9 +58,15 @@ void MainWindow::setupUI()
     // 创建主布局
     QVBoxLayout *mainLayout = new QVBoxLayout(centralWidget);
 
-    // 创建提醒列表
-    reminderList = new ReminderList(this);
-    mainLayout->addWidget(reminderList);
+    tabWidget = new QTabWidget(centralWidget);
+
+    reminderList = new ReminderList(ReminderList::Mode::Active, tabWidget);
+    completedList = new ReminderList(ReminderList::Mode::Completed, tabWidget);
+
+    tabWidget->addTab(reminderList, tr("当前提醒"));
+    tabWidget->addTab(completedList, tr("已完成提醒"));
+
+    mainLayout->addWidget(tabWidget);
 
     centralWidget->setLayout(mainLayout);
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -6,6 +6,7 @@
 #include <QMenu>
 #include <QAction>
 #include "reminderlist.h"
+#include <QTabWidget>
 #include "remindermanager.h"
 
 QT_BEGIN_NAMESPACE
@@ -34,6 +35,8 @@ private:
 
     Ui::MainWindow *ui;
     ReminderList *reminderList;
+    ReminderList *completedList;
+    QTabWidget *tabWidget;
     ReminderManager *reminderManager;
     QSystemTrayIcon *trayIcon;
     QMenu *trayIconMenu;

--- a/src/reminderlist.h
+++ b/src/reminderlist.h
@@ -18,7 +18,12 @@ class ReminderList : public QWidget
     Q_OBJECT
 
 public:
-    explicit ReminderList(QWidget *parent = nullptr);
+    enum class Mode {
+        Active,
+        Completed
+    };
+
+    explicit ReminderList(Mode mode = Mode::Active, QWidget *parent = nullptr);
     ~ReminderList();
 
     void setReminderManager(ReminderManager *manager);
@@ -53,6 +58,7 @@ private:
     QSortFilterProxyModel *proxyModel;
     ReminderEdit *editDialog;
     QString m_searchText;
+    Mode m_mode;
 };
 
 #endif // REMINDERLIST_H 


### PR DESCRIPTION
## Summary
- support active/completed modes in `ReminderList`
- filter reminders by completion status
- disable editing on completed reminder list
- show active and completed lists in a tab widget

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684d61d65a748331909678ee556b3a74