### PR TITLE
Disable editing in completed reminders

### DIFF
--- a/src/reminderlist.cpp
+++ b/src/reminderlist.cpp
@@ -70,17 +70,22 @@ void ReminderList::setupConnections()
     LOG_INFO("设置信号连接");
     connect(ui->searchEdit, &QLineEdit::textChanged,
             this, &ReminderList::onSearchTextChanged);
-    connect(ui->addButton, &QPushButton::clicked,
-            this, &ReminderList::onAddClicked);
-    connect(ui->deleteButton, &QPushButton::clicked,
-            this, &ReminderList::onDeleteClicked);
-    connect(ui->importButton, &QPushButton::clicked,
-            this, &ReminderList::onImportClicked);
-    connect(ui->exportButton, &QPushButton::clicked,
-            this, &ReminderList::onExportClicked);
     if (m_mode == Mode::Active) {
+        connect(ui->addButton, &QPushButton::clicked,
+                this, &ReminderList::onAddClicked);
+        connect(ui->deleteButton, &QPushButton::clicked,
+                this, &ReminderList::onDeleteClicked);
+        connect(ui->importButton, &QPushButton::clicked,
+                this, &ReminderList::onImportClicked);
+        connect(ui->exportButton, &QPushButton::clicked,
+                this, &ReminderList::onExportClicked);
         connect(ui->tableView, &QTableView::doubleClicked,
                 this, &ReminderList::onEditClicked);
+    } else {
+        ui->addButton->setVisible(false);
+        ui->deleteButton->setVisible(false);
+        ui->importButton->setVisible(false);
+        ui->exportButton->setVisible(false);
     }
     LOG_INFO("信号连接设置完成");
 }

--- a/src/remindermanager.cpp
+++ b/src/remindermanager.cpp
@@ -27,7 +27,7 @@ void ReminderManager::setupTimer()
 {
     LOG_INFO("设置定时器");
     connect(checkTimer, &QTimer::timeout, this, &ReminderManager::checkReminders);
-    checkTimer->start(5000); // 每秒检查一次
+    checkTimer->start(5000); // 每5秒检查一次
 }
 
 void ReminderManager::loadReminders()


### PR DESCRIPTION
## Summary
- hide add/import/export buttons when viewing completed reminders
- fix comment on reminder timer interval

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d6a6dd48c8331931a4041708f1d8b