### PR TITLE
Add stacking logic for notification popups

### DIFF
--- a/src/notificationPopup.h
+++ b/src/notificationPopup.h
@@ -8,6 +8,9 @@
 #include <QPushButton>
 #include <QScopedPointer>
 #include "ui_notificationPopup.h"
+#include <QList>
+#include <QPointer>
+#include <QCloseEvent>
 
 class NotificationPopup : public QWidget {
     Q_OBJECT
@@ -20,7 +23,12 @@ public:
     
     void show();
 
+protected:
+    void closeEvent(QCloseEvent *event) override;
+
 private:
+    static QList<QPointer<NotificationPopup>> s_popups;
+    void repositionPopups();
     QScopedPointer<Ui::NotificationPopup> ui;
     QPropertyAnimation *fadeIn, *fadeOut;
     QString m_message;


### PR DESCRIPTION
## Summary
- allow multiple `NotificationPopup` windows to stack from the bottom-right corner
- reuse screen geometry when popups close and shift remaining popups

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d70dd8a6483319c7c8de3b1a5d703