### PR TITLE
Fix NotificationPopup include casing

### DIFF
--- a/src/notificationPopup.cpp
+++ b/src/notificationPopup.cpp
@@ -3,7 +3,7 @@
 #include <QApplication>
 #include <QPushButton>
 #include <QStyle>
-#include "NotificationPopup.h"
+#include "notificationPopup.h"
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 #include "ui_notificationPopup.h"

--- a/src/remindermanager.h
+++ b/src/remindermanager.h
@@ -4,7 +4,7 @@
 #include <QObject>
 #include <QTimer>
 #include <QJsonArray>
-#include "NotificationPopup.h"
+#include "notificationPopup.h"
 #include <QVector>
 #include "reminder.h"
 #include "configmanager.h"


### PR DESCRIPTION
## Summary
- fix include path for `notificationPopup.h` in `notificationPopup.cpp`
- fix include path for `notificationPopup.h` in `remindermanager.h`

## Testing
- `g++ -c src/notificationPopup.cpp -Isrc` *(fails: `QScreen: No such file or directory`)*
- `g++ -c src/remindermanager.cpp -Isrc` *(fails: `ReminderManager.h: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_684e3a76789c83319a01a7d244974daf