### PR TITLE
Add overloaded ReminderList constructor

### DIFF
--- a/src/reminderlist.cpp
+++ b/src/reminderlist.cpp
@@ -38,6 +38,11 @@ ReminderList::ReminderList(Mode mode, QWidget *parent)
     LOG_INFO("提醒列表界面初始化完成");
 }
 
+ReminderList::ReminderList(QWidget *parent)
+    : ReminderList(Mode::Active, parent)
+{
+}
+
 ReminderList::~ReminderList()
 {
     LOG_INFO("销毁提醒列表界面");

--- a/src/reminderlist.h
+++ b/src/reminderlist.h
@@ -24,6 +24,7 @@ public:
     };
 
     explicit ReminderList(Mode mode = Mode::Active, QWidget *parent = nullptr);
+    explicit ReminderList(QWidget *parent = nullptr);
     ~ReminderList();
 
     void setReminderManager(ReminderManager *manager);


### PR DESCRIPTION
## Summary
- introduce `ReminderList(QWidget* parent)` constructor
- implement delegating constructor in ReminderList implementation

## Testing
- `qmake` *(fails: command not found)*
- `nmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e3a7051548331a34a2293b08fd445