### PR TITLE
Fix ReminderList initialization

### DIFF
--- a/src/activereminderwindow.cpp
+++ b/src/activereminderwindow.cpp
@@ -3,12 +3,9 @@
 
 ActiveReminderWindow::ActiveReminderWindow(QWidget *parent)
     : QWidget(parent),
-      ui(new Ui::ActiveReminderWindow),
-      reminderList(nullptr)
+      ui(new Ui::ActiveReminderWindow)
 {
     ui->setupUi(this);
-    reminderList = new ReminderList(ReminderList::Mode::Active, this);
-    ui->verticalLayout->addWidget(reminderList);
 }
 
 ActiveReminderWindow::~ActiveReminderWindow()
@@ -18,6 +15,6 @@ ActiveReminderWindow::~ActiveReminderWindow()
 
 void ActiveReminderWindow::setReminderManager(ReminderManager *manager)
 {
-    if (reminderList)
-        reminderList->setReminderManager(manager);
+    if (ui->activeList)
+        ui->activeList->setReminderManager(manager);
 }

--- a/src/activereminderwindow.h
+++ b/src/activereminderwindow.h
@@ -20,7 +20,6 @@ public:
 
 private:
     Ui::ActiveReminderWindow *ui;
-    ReminderList *reminderList;
 };
 
 #endif // ACTIVEREMINDERWINDOW_H

--- a/src/completedreminderwindow.cpp
+++ b/src/completedreminderwindow.cpp
@@ -3,12 +3,9 @@
 
 CompletedReminderWindow::CompletedReminderWindow(QWidget *parent)
     : QWidget(parent),
-      ui(new Ui::CompletedReminderWindow),
-      reminderList(nullptr)
+      ui(new Ui::CompletedReminderWindow)
 {
     ui->setupUi(this);
-    reminderList = new ReminderList(ReminderList::Mode::Completed, this);
-    ui->verticalLayout->addWidget(reminderList);
 }
 
 CompletedReminderWindow::~CompletedReminderWindow()
@@ -18,6 +15,6 @@ CompletedReminderWindow::~CompletedReminderWindow()
 
 void CompletedReminderWindow::setReminderManager(ReminderManager *manager)
 {
-    if (reminderList)
-        reminderList->setReminderManager(manager);
+    if (ui->completedList)
+        ui->completedList->setReminderManager(manager);
 }

--- a/src/completedreminderwindow.h
+++ b/src/completedreminderwindow.h
@@ -20,7 +20,6 @@ public:
 
 private:
     Ui::CompletedReminderWindow *ui;
-    ReminderList *reminderList;
 };
 
 #endif // COMPLETEDREMINDERWINDOW_H


### PR DESCRIPTION
## Summary
- remove manual ReminderList creation in ActiveReminderWindow and CompletedReminderWindow
- rely on ReminderList widget already defined in their UI forms
- update member declarations accordingly

## Testing
- `qmake && make -j$(nproc)` *(fails: `qmake` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e4aa4d144833182e7bdaabd5b743a