### PR TITLE
Fix include path in ReminderManager

### DIFF
--- a/src/remindermanager.cpp
+++ b/src/remindermanager.cpp
@@ -1,4 +1,4 @@
-#include "ReminderManager.h"
+#include "remindermanager.h"
 #include <QJsonArray>
 #include <QIcon>
 #include "logger.h"


### PR DESCRIPTION
## Summary
- fix incorrect header include in `remindermanager.cpp`

## Testing
- `qmake --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e4aa708ac8331a0481d56244049e7