### PR TITLE
Simplify reminder list and move filtering logic

### DIFF
--- a/src/activereminderwindow.cpp
+++ b/src/activereminderwindow.cpp
@@ -1,14 +1,29 @@
 #include "activereminderwindow.h"
 #include "ui_activereminderwindow.h"
+#include <QPushButton>
+#include <QTableView>
 
 ActiveReminderWindow::ActiveReminderWindow(QWidget *parent)
     : QWidget(parent),
       ui(new Ui::ActiveReminderWindow),
-      reminderList(nullptr)
+      reminderList(nullptr),
+      reminderManager(nullptr)
 {
     ui->setupUi(this);
-    reminderList = new ReminderList(ReminderList::Mode::Active, this);
+    reminderList = new ReminderList(this);
     ui->verticalLayout->addWidget(reminderList);
+
+    // connect buttons to reminder list slots
+    if (QPushButton *btn = reminderList->findChild<QPushButton*>("addButton"))
+        connect(btn, &QPushButton::clicked, reminderList, &ReminderList::onAddClicked);
+    if (QPushButton *btn = reminderList->findChild<QPushButton*>("deleteButton"))
+        connect(btn, &QPushButton::clicked, reminderList, &ReminderList::onDeleteClicked);
+    if (QPushButton *btn = reminderList->findChild<QPushButton*>("importButton"))
+        connect(btn, &QPushButton::clicked, reminderList, &ReminderList::onImportClicked);
+    if (QPushButton *btn = reminderList->findChild<QPushButton*>("exportButton"))
+        connect(btn, &QPushButton::clicked, reminderList, &ReminderList::onExportClicked);
+    if (QTableView *tv = reminderList->findChild<QTableView*>("tableView"))
+        connect(tv, &QTableView::doubleClicked, reminderList, &ReminderList::onEditClicked);
 }
 
 ActiveReminderWindow::~ActiveReminderWindow()
@@ -18,6 +33,25 @@ ActiveReminderWindow::~ActiveReminderWindow()
 
 void ActiveReminderWindow::setReminderManager(ReminderManager *manager)
 {
+    if (reminderManager)
+        disconnect(reminderManager, &ReminderManager::reminderTriggered, this, &ActiveReminderWindow::refreshReminders);
+    reminderManager = manager;
     if (reminderList)
         reminderList->setReminderManager(manager);
+    if (reminderManager) {
+        connect(reminderManager, &ReminderManager::reminderTriggered, this, &ActiveReminderWindow::refreshReminders);
+        refreshReminders();
+    }
+}
+
+void ActiveReminderWindow::refreshReminders()
+{
+    if (!reminderManager)
+        return;
+    QList<Reminder> filtered;
+    for (const Reminder &r : reminderManager->getReminders()) {
+        if (!r.completed())
+            filtered.append(r);
+    }
+    reminderList->updateList(filtered);
 }

--- a/src/activereminderwindow.h
+++ b/src/activereminderwindow.h
@@ -18,9 +18,13 @@ public:
 
     void setReminderManager(ReminderManager *manager);
 
+private slots:
+    void refreshReminders();
+
 private:
     Ui::ActiveReminderWindow *ui;
     ReminderList *reminderList;
+    ReminderManager *reminderManager;
 };
 
 #endif // ACTIVEREMINDERWINDOW_H

--- a/src/completedreminderwindow.cpp
+++ b/src/completedreminderwindow.cpp
@@ -1,14 +1,26 @@
 #include "completedreminderwindow.h"
 #include "ui_completedreminderwindow.h"
+#include <QPushButton>
 
 CompletedReminderWindow::CompletedReminderWindow(QWidget *parent)
     : QWidget(parent),
       ui(new Ui::CompletedReminderWindow),
-      reminderList(nullptr)
+      reminderList(nullptr),
+      reminderManager(nullptr)
 {
     ui->setupUi(this);
-    reminderList = new ReminderList(ReminderList::Mode::Completed, this);
+    reminderList = new ReminderList(this);
     ui->verticalLayout->addWidget(reminderList);
+
+    // hide editing buttons
+    if (QPushButton *btn = reminderList->findChild<QPushButton*>("addButton"))
+        btn->setVisible(false);
+    if (QPushButton *btn = reminderList->findChild<QPushButton*>("deleteButton"))
+        btn->setVisible(false);
+    if (QPushButton *btn = reminderList->findChild<QPushButton*>("importButton"))
+        btn->setVisible(false);
+    if (QPushButton *btn = reminderList->findChild<QPushButton*>("exportButton"))
+        btn->setVisible(false);
 }
 
 CompletedReminderWindow::~CompletedReminderWindow()
@@ -18,6 +30,25 @@ CompletedReminderWindow::~CompletedReminderWindow()
 
 void CompletedReminderWindow::setReminderManager(ReminderManager *manager)
 {
+    if (reminderManager)
+        disconnect(reminderManager, &ReminderManager::reminderTriggered, this, &CompletedReminderWindow::refreshReminders);
+    reminderManager = manager;
     if (reminderList)
         reminderList->setReminderManager(manager);
+    if (reminderManager) {
+        connect(reminderManager, &ReminderManager::reminderTriggered, this, &CompletedReminderWindow::refreshReminders);
+        refreshReminders();
+    }
+}
+
+void CompletedReminderWindow::refreshReminders()
+{
+    if (!reminderManager)
+        return;
+    QList<Reminder> filtered;
+    for (const Reminder &r : reminderManager->getReminders()) {
+        if (r.completed())
+            filtered.append(r);
+    }
+    reminderList->updateList(filtered);
 }

--- a/src/completedreminderwindow.h
+++ b/src/completedreminderwindow.h
@@ -18,9 +18,13 @@ public:
 
     void setReminderManager(ReminderManager *manager);
 
+private slots:
+    void refreshReminders();
+
 private:
     Ui::CompletedReminderWindow *ui;
     ReminderList *reminderList;
+    ReminderManager *reminderManager;
 };
 
 #endif // COMPLETEDREMINDERWINDOW_H

--- a/src/reminderlist.cpp
+++ b/src/reminderlist.cpp
@@ -22,14 +22,13 @@ enum ColumnIndex {
     NextTrigger = 2
 };
 
-ReminderList::ReminderList(Mode mode, QWidget *parent)
+ReminderList::ReminderList(QWidget *parent)
     : QWidget(parent)
     , ui(new Ui::ReminderList)
     , reminderManager(nullptr)
     , model(new ReminderTableModel(this))
     , proxyModel(new QSortFilterProxyModel(this))
     , editDialog(new ReminderEdit(this))
-    , m_mode(mode)
 {
     LOG_INFO("创建提醒列表界面");
     ui->setupUi(this);
@@ -38,10 +37,7 @@ ReminderList::ReminderList(Mode mode, QWidget *parent)
     LOG_INFO("提醒列表界面初始化完成");
 }
 
-ReminderList::ReminderList(QWidget *parent)
-    : ReminderList(Mode::Active, parent)
-{
-}
+
 
 ReminderList::~ReminderList()
 {
@@ -53,21 +49,12 @@ void ReminderList::setReminderManager(ReminderManager *manager)
 {
     LOG_INFO("设置提醒管理器");
     reminderManager = manager;
-    if (reminderManager) {
-        connect(reminderManager, &ReminderManager::reminderTriggered,
-                this, &ReminderList::onReminderTriggered, Qt::AutoConnection);
-        QList<Reminder> filtered;
-        const QVector<Reminder> all = reminderManager->getReminders();
-        for (const Reminder &r : all) {
-            if (m_mode == Mode::Completed && r.completed()) {
-                filtered.append(r);
-            } else if (m_mode == Mode::Active && !r.completed()) {
-                filtered.append(r);
-            }
-        }
-        loadReminders(filtered);
-        LOG_INFO("提醒管理器设置完成，已加载提醒列表");
-    }
+}
+
+void ReminderList::updateList(const QList<Reminder> &reminders)
+{
+    loadReminders(reminders);
+    refreshList();
 }
 
 void ReminderList::setupConnections()
@@ -75,24 +62,6 @@ void ReminderList::setupConnections()
     LOG_INFO("设置信号连接");
     connect(ui->searchEdit, &QLineEdit::textChanged,
             this, &ReminderList::onSearchTextChanged);
-    if (m_mode == Mode::Active) {
-        connect(ui->addButton, &QPushButton::clicked,
-                this, &ReminderList::onAddClicked);
-        connect(ui->deleteButton, &QPushButton::clicked,
-                this, &ReminderList::onDeleteClicked);
-        connect(ui->importButton, &QPushButton::clicked,
-                this, &ReminderList::onImportClicked);
-        connect(ui->exportButton, &QPushButton::clicked,
-                this, &ReminderList::onExportClicked);
-        connect(ui->tableView, &QTableView::doubleClicked,
-                this, &ReminderList::onEditClicked);
-    } else {
-        ui->addButton->setVisible(false);
-        ui->importButton->setVisible(false);
-        ui->exportButton->setVisible(false);
-        connect(ui->deleteButton, &QPushButton::clicked,
-                this, &ReminderList::onDeleteClicked);
-    }
     LOG_INFO("信号连接设置完成");
 }
 
@@ -281,25 +250,6 @@ QJsonObject ReminderList::getReminderData(const QString &name) const
     return QJsonObject();
 }
 
-void ReminderList::onReminderTriggered(const Reminder &reminder)
-{
-    LOG_INFO(QString("提醒触发: 名称='%1'").arg(reminder.name()));
-    if (!reminderManager)
-        return;
-
-    QList<Reminder> filtered;
-    const QVector<Reminder> all = reminderManager->getReminders();
-    for (const Reminder &r : all) {
-        if (m_mode == Mode::Completed && r.completed()) {
-            filtered.append(r);
-        } else if (m_mode == Mode::Active && !r.completed()) {
-            filtered.append(r);
-        }
-    }
-    loadReminders(filtered);
-    refreshList();
-}
-
 void ReminderList::onAddClicked()
 {
     addNewReminder();
@@ -307,8 +257,6 @@ void ReminderList::onAddClicked()
 
 void ReminderList::onEditClicked()
 {
-    if (m_mode == Mode::Completed)
-        return;
     QModelIndex currentIndex = ui->tableView->currentIndex();
     if (currentIndex.isValid()) {
         editReminder(currentIndex);

--- a/src/reminderlist.h
+++ b/src/reminderlist.h
@@ -18,20 +18,13 @@ class ReminderList : public QWidget
     Q_OBJECT
 
 public:
-    enum class Mode {
-        Active,
-        Completed
-    };
-
-    explicit ReminderList(Mode mode = Mode::Active, QWidget *parent = nullptr);
     explicit ReminderList(QWidget *parent = nullptr);
     ~ReminderList();
 
     void setReminderManager(ReminderManager *manager);
+    void updateList(const QList<Reminder> &reminders);
 
-
-private slots:
-    void onReminderTriggered(const Reminder &reminder);
+public slots:
     void onAddClicked();
     void onEditClicked();
     void onDeleteClicked();
@@ -59,7 +52,6 @@ private:
     QSortFilterProxyModel *proxyModel;
     ReminderEdit *editDialog;
     QString m_searchText;
-    Mode m_mode;
 };
 
 #endif // REMINDERLIST_H 


### PR DESCRIPTION
## Summary
- drop `ReminderList` mode concept
- filter reminders and connect buttons inside each window
- make active window handle add/edit/delete/import/export
- update windows on reminder trigger events

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e4aa977488331a1d61a7eac64b9f9