### PR TITLE
Refactor reminder windows

### DIFF
--- a/src/activereminderwindow.cpp
+++ b/src/activereminderwindow.cpp
@@ -1,11 +1,28 @@
 #include "activereminderwindow.h"
 #include "ui_activereminderwindow.h"
+#include <QPushButton>
+#include <QTableView>
+#include <QModelIndex>
 
 ActiveReminderWindow::ActiveReminderWindow(QWidget *parent)
-    : QWidget(parent),
-      ui(new Ui::ActiveReminderWindow)
+    : QWidget(parent)
+    , ui(new Ui::ActiveReminderWindow)
+    , reminderManager(nullptr)
 {
     ui->setupUi(this);
+
+    if (ui->activeList) {
+        connect(ui->activeList->addButton(), &QPushButton::clicked,
+                this, [this]() { ui->activeList->onAddClicked(); refreshReminders(); });
+        connect(ui->activeList->deleteButton(), &QPushButton::clicked,
+                this, [this]() { ui->activeList->onDeleteClicked(); refreshReminders(); });
+        connect(ui->activeList->importButton(), &QPushButton::clicked,
+                this, [this]() { ui->activeList->onImportClicked(); refreshReminders(); });
+        connect(ui->activeList->exportButton(), &QPushButton::clicked,
+                ui->activeList, &ReminderList::onExportClicked);
+        connect(ui->activeList->tableView(), &QTableView::doubleClicked,
+                this, [this](const QModelIndex &) { ui->activeList->onEditClicked(); refreshReminders(); });
+    }
 }
 
 ActiveReminderWindow::~ActiveReminderWindow()
@@ -15,6 +32,25 @@ ActiveReminderWindow::~ActiveReminderWindow()
 
 void ActiveReminderWindow::setReminderManager(ReminderManager *manager)
 {
+    reminderManager = manager;
     if (ui->activeList)
         ui->activeList->setReminderManager(manager);
+    if (reminderManager) {
+        connect(reminderManager, &ReminderManager::reminderTriggered,
+                this, &ActiveReminderWindow::refreshReminders, Qt::UniqueConnection);
+    }
+    refreshReminders();
+}
+
+void ActiveReminderWindow::refreshReminders()
+{
+    if (!reminderManager)
+        return;
+    QList<Reminder> filtered;
+    const QVector<Reminder> all = reminderManager->getReminders();
+    for (const Reminder &r : all) {
+        if (!r.completed())
+            filtered.append(r);
+    }
+    ui->activeList->loadReminders(filtered);
 }

--- a/src/activereminderwindow.h
+++ b/src/activereminderwindow.h
@@ -18,8 +18,12 @@ public:
 
     void setReminderManager(ReminderManager *manager);
 
+private slots:
+    void refreshReminders();
+
 private:
     Ui::ActiveReminderWindow *ui;
+    ReminderManager *reminderManager;
 };
 
 #endif // ACTIVEREMINDERWINDOW_H

--- a/src/completedreminderwindow.cpp
+++ b/src/completedreminderwindow.cpp
@@ -1,11 +1,23 @@
 #include "completedreminderwindow.h"
 #include "ui_completedreminderwindow.h"
+#include <QPushButton>
+#include <QTableView>
+#include <QModelIndex>
 
 CompletedReminderWindow::CompletedReminderWindow(QWidget *parent)
-    : QWidget(parent),
-      ui(new Ui::CompletedReminderWindow)
+    : QWidget(parent)
+    , ui(new Ui::CompletedReminderWindow)
+    , reminderManager(nullptr)
 {
     ui->setupUi(this);
+
+    if (ui->completedList) {
+        ui->completedList->addButton()->setVisible(false);
+        ui->completedList->importButton()->setVisible(false);
+        ui->completedList->exportButton()->setVisible(false);
+        connect(ui->completedList->deleteButton(), &QPushButton::clicked,
+                this, [this]() { ui->completedList->onDeleteClicked(); refreshReminders(); });
+    }
 }
 
 CompletedReminderWindow::~CompletedReminderWindow()
@@ -15,6 +27,25 @@ CompletedReminderWindow::~CompletedReminderWindow()
 
 void CompletedReminderWindow::setReminderManager(ReminderManager *manager)
 {
+    reminderManager = manager;
     if (ui->completedList)
         ui->completedList->setReminderManager(manager);
+    if (reminderManager) {
+        connect(reminderManager, &ReminderManager::reminderTriggered,
+                this, &CompletedReminderWindow::refreshReminders, Qt::UniqueConnection);
+    }
+    refreshReminders();
+}
+
+void CompletedReminderWindow::refreshReminders()
+{
+    if (!reminderManager)
+        return;
+    QList<Reminder> filtered;
+    const QVector<Reminder> all = reminderManager->getReminders();
+    for (const Reminder &r : all) {
+        if (r.completed())
+            filtered.append(r);
+    }
+    ui->completedList->loadReminders(filtered);
 }

--- a/src/completedreminderwindow.h
+++ b/src/completedreminderwindow.h
@@ -18,8 +18,12 @@ public:
 
     void setReminderManager(ReminderManager *manager);
 
+private slots:
+    void refreshReminders();
+
 private:
     Ui::CompletedReminderWindow *ui;
+    ReminderManager *reminderManager;
 };
 
 #endif // COMPLETEDREMINDERWINDOW_H

--- a/src/reminderlist.h
+++ b/src/reminderlist.h
@@ -8,6 +8,8 @@
 #include "reminderedit.h"
 #include "remindermanager.h"
 #include "remindertablemodel.h"
+#include <QPushButton>
+#include <QTableView>
 
 QT_BEGIN_NAMESPACE
 namespace Ui { class ReminderList; }
@@ -18,20 +20,19 @@ class ReminderList : public QWidget
     Q_OBJECT
 
 public:
-    enum class Mode {
-        Active,
-        Completed
-    };
-
-    explicit ReminderList(Mode mode = Mode::Active, QWidget *parent = nullptr);
     explicit ReminderList(QWidget *parent = nullptr);
     ~ReminderList();
 
     void setReminderManager(ReminderManager *manager);
+    void loadReminders(const QList<Reminder> &reminders);
+    QJsonArray getReminders() const;
+    QPushButton *addButton() const;
+    QPushButton *deleteButton() const;
+    QPushButton *importButton() const;
+    QPushButton *exportButton() const;
+    QTableView *tableView() const;
 
-
-private slots:
-    void onReminderTriggered(const Reminder &reminder);
+public slots:
     void onAddClicked();
     void onEditClicked();
     void onDeleteClicked();
@@ -42,8 +43,6 @@ private slots:
 private:
     void setupConnections();
     void setupModel();
-    void loadReminders(const QList<Reminder> &reminders);
-    QJsonArray getReminders() const;
     void addNewReminder();
     void editReminder(const QModelIndex &index);
     void deleteReminder(const QModelIndex &index);
@@ -59,7 +58,6 @@ private:
     QSortFilterProxyModel *proxyModel;
     ReminderEdit *editDialog;
     QString m_searchText;
-    Mode m_mode;
 };
 
 #endif // REMINDERLIST_H 


### PR DESCRIPTION
## Summary
- simplify `ReminderList` to remove mode handling
- expose reminder list controls for external connection
- handle active/completed filtering in window classes
- connect reminder list buttons in `ActiveReminderWindow`
- hide irrelevant buttons in `CompletedReminderWindow`

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e618728d483318f463e4e5b7318a7