### PR TITLE
Add active/completed reminder lists

### DIFF
--- a/EasyNotify.pro
+++ b/EasyNotify.pro
@@ -13,6 +13,10 @@ SOURCES += \
     src/mainwindow.cpp \
     src/reminderlist.cpp \
     src/reminderedit.cpp \
+    src/active_reminderlist.cpp \
+    src/completed_reminderlist.cpp \
+    src/active_reminderedit.cpp \
+    src/completed_reminderedit.cpp \
     src/remindermanager.cpp \
     src/logger.cpp \
     src/notificationPopup.cpp \
@@ -20,6 +24,8 @@ SOURCES += \
     src/singleinstance.cpp \
     src/reminder.cpp   \
     src/remindertablemodel.cpp \
+    src/active_remindertablemodel.cpp \
+    src/completed_remindertablemodel.cpp \
     src/activereminderwindow.cpp \
     src/completedreminderwindow.cpp
 
@@ -27,6 +33,10 @@ HEADERS += \
     src/mainwindow.h \
     src/reminderlist.h \
     src/reminderedit.h \
+    src/active_reminderlist.h \
+    src/completed_reminderlist.h \
+    src/active_reminderedit.h \
+    src/completed_reminderedit.h \
     src/remindermanager.h \
     src/logger.h \
     src/notificationPopup.h \
@@ -34,6 +44,8 @@ HEADERS += \
     src/singleinstance.h \
     src/reminder.h \
     src/remindertablemodel.h \
+    src/active_remindertablemodel.h \
+    src/completed_remindertablemodel.h \
     src/activereminderwindow.h \
     src/completedreminderwindow.h
 

--- a/src/active_reminderedit.cpp
+++ b/src/active_reminderedit.cpp
@@ -1,0 +1,189 @@
+#include "active_reminderedit.h"
+#include "ui_reminderedit.h"
+#include <QMessageBox>
+#include <QUuid>
+#include <QDateTime>
+#include <QFile>
+#include <QPushButton>
+#include "logger.h"
+
+
+ActiveReminderEdit::ActiveReminderEdit(QWidget *parent)
+    : QDialog(parent)
+    , ui(new Ui::ReminderEdit)
+{
+    LOG_INFO("创建提醒编辑对话框");
+    ui->setupUi(this);
+    setupConnections();
+    LOG_INFO("提醒编辑对话框初始化完成");
+}
+
+ActiveReminderEdit::~ActiveReminderEdit()
+{
+    LOG_INFO("销毁提醒编辑对话框");
+    delete ui;
+}
+
+void ActiveReminderEdit::prepareNewReminder()
+{
+    LOG_INFO("初始化新建提醒");
+    setWindowTitle(tr("新增提醒"));
+
+    ui->nameEdit->clear();
+    QDateTime now = QDateTime::currentDateTime();
+    ui->dateTimeEdit->setDateTime(now);
+    ui->timeEdit->setTime(now.time());
+    ui->typeCombo->setCurrentIndex(0);
+
+    m_reminder = Reminder();
+    m_reminder.setId(QUuid::createUuid().toString(QUuid::WithoutBraces));
+    m_reminder.setType(Reminder::Type::Once);
+    m_reminder.setNextTrigger(now);
+
+    onTypeChanged(0);
+    LOG_INFO("新建提醒准备完成");
+}
+
+void ActiveReminderEdit::setupConnections()
+{
+    connect(ui->typeCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, &ActiveReminderEdit::onTypeChanged);
+    connect(ui->dateTimeEdit, &QDateTimeEdit::dateTimeChanged,
+            this, &ActiveReminderEdit::onDateTimeChanged);
+    connect(ui->buttonBox, &QDialogButtonBox::accepted,
+            this, &ActiveReminderEdit::onOkClicked);
+    connect(ui->buttonBox, &QDialogButtonBox::rejected,
+            this, &ActiveReminderEdit::onCancelClicked);
+}
+
+void ActiveReminderEdit::prepareEditReminder(const Reminder &reminder)
+{
+    LOG_INFO("加载待编辑的提醒数据");
+    setWindowTitle(tr("编辑提醒"));
+
+    m_reminder = reminder;
+    ui->nameEdit->setText(reminder.name());
+
+    int type = static_cast<int>(reminder.type());
+    ui->typeCombo->setCurrentIndex(type);
+
+    QDateTime nextTrigger = reminder.nextTrigger();
+    if (reminder.type() == Reminder::Type::Once) {
+        ui->dateTimeEdit->setDateTime(nextTrigger);
+    } else {
+        ui->timeEdit->setTime(nextTrigger.time());
+    }
+
+    onTypeChanged(type);
+    LOG_INFO("编辑提醒准备完成");
+}
+
+
+Reminder ActiveReminderEdit::getReminder() const
+{
+    return m_reminder;
+}
+
+void ActiveReminderEdit::onTypeChanged(int index)
+{
+    LOG_INFO(QString("提醒类型变更为: %1").arg(index));
+    // 先全部隐藏
+    ui->dateTimeEdit->hide();
+    ui->timeEdit->hide();
+    ui->dateTimeLabel->hide();
+    ui->timeLabel->hide();
+
+    switch (index) {
+        case 0: // 一次性
+            ui->dateTimeEdit->show();
+            ui->dateTimeLabel->show();
+            m_reminder.setType(Reminder::Type::Once);
+            break;
+        case 1: // 每天
+            ui->timeEdit->show();
+            ui->timeLabel->show();
+            m_reminder.setType(Reminder::Type::Daily);
+            break;
+    }
+    updateNextTriggerTime();
+}
+
+void ActiveReminderEdit::onDateTimeChanged(const QDateTime &dateTime)
+{
+    LOG_INFO(QString("日期时间变更为: %1").arg(dateTime.toString("yyyy-MM-dd HH:mm:ss")));
+    updateNextTriggerTime();
+}
+
+void ActiveReminderEdit::onOkClicked()
+{
+    LOG_INFO("点击确定按钮");
+    if (validateInput()) {
+        QString name = ui->nameEdit->text().trimmed();
+        m_reminder.setName(name);
+        updateNextTriggerTime();
+
+        LOG_INFO(QString("保存提醒: ID='%1', 名称='%2', 类型='%3'")
+                 .arg(m_reminder.id())
+                 .arg(name)
+                 .arg(static_cast<int>(m_reminder.type())));
+        accept();
+    } else {
+        LOG_WARNING("输入验证失败，无法保存提醒");
+    }
+}
+
+void ActiveReminderEdit::onCancelClicked()
+{
+    LOG_INFO("点击取消按钮，关闭对话框");
+    reject();
+}
+
+void ActiveReminderEdit::onDaysChanged()
+{
+    LOG_INFO("星期/日期选择发生变化");
+    updateNextTriggerTime();
+}
+
+QDateTime ActiveReminderEdit::calculateNextTrigger() const
+{
+    QDateTime now = QDateTime::currentDateTime();
+    QDateTime nextTrigger;
+    Reminder::Type type = static_cast<Reminder::Type>(ui->typeCombo->currentIndex());
+
+    switch (type) {
+        case Reminder::Type::Once: {
+            nextTrigger = ui->dateTimeEdit->dateTime();
+            LOG_INFO(QString("计算一次性提醒时间: %1").arg(nextTrigger.toString("yyyy-MM-dd HH:mm:ss")));
+            break;
+        }
+        case Reminder::Type::Daily: {
+            QTime time = ui->timeEdit->time();
+            nextTrigger = QDateTime(now.date(), time);
+            if (nextTrigger <= now) {
+                nextTrigger = nextTrigger.addDays(1);
+            }
+            LOG_INFO(QString("计算每日提醒时间: %1").arg(nextTrigger.toString("yyyy-MM-dd HH:mm:ss")));
+            break;
+        }
+    }
+
+    return nextTrigger;
+}
+
+bool ActiveReminderEdit::validateInput() const
+{
+    bool isValid = !ui->nameEdit->text().trimmed().isEmpty();
+    ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(isValid);
+    if (!isValid) {
+        LOG_WARNING("提醒名称不能为空");
+    }
+    return isValid;
+}
+
+void ActiveReminderEdit::updateNextTriggerTime()
+{
+    QDateTime nextTime = calculateNextTrigger();
+    ui->nextTriggerLabel->setText(nextTime.toString("yyyy-MM-dd HH:mm:ss"));
+    m_reminder.setNextTrigger(nextTime);
+    LOG_INFO(QString("更新下次触发时间: %1").arg(nextTime.toString("yyyy-MM-dd HH:mm:ss")));
+}

--- a/src/active_reminderedit.h
+++ b/src/active_reminderedit.h
@@ -1,0 +1,43 @@
+#ifndef ACTIVE_REMINDEREDIT_H
+#define ACTIVE_REMINDEREDIT_H
+
+#include <QDialog>
+#include "reminder.h"
+#include <QStringList>
+#include <QDateTime>
+
+namespace Ui {
+class ReminderEdit;
+}
+
+class ActiveReminderEdit : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit ActiveReminderEdit(QWidget *parent = nullptr);
+    ~ActiveReminderEdit();
+
+    void prepareEditReminder(const Reminder &reminder);
+    void prepareNewReminder();
+    Reminder getReminder() const;
+
+private slots:
+    void onTypeChanged(int index);
+    void onOkClicked();
+    void onCancelClicked();
+    void onDateTimeChanged(const QDateTime &dateTime);
+    void onDaysChanged();
+
+private:
+    void setupConnections();
+    QDateTime calculateNextTrigger() const;
+    bool validateInput() const;
+    void updateNextTriggerTime();
+
+    Ui::ReminderEdit *ui;
+    Reminder m_reminder;
+
+};
+
+#endif // ACTIVE_REMINDEREDIT_H 

--- a/src/active_reminderlist.cpp
+++ b/src/active_reminderlist.cpp
@@ -1,0 +1,370 @@
+#include "active_reminderlist.h"
+#include "ui_reminderlist.h"
+#include <QHeaderView>
+#include <QMessageBox>
+#include <QJsonDocument>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QFile>
+#include <QDateTime>
+#include <QFileDialog>
+#include "remindermanager.h"
+#include "logger.h"
+#include "active_reminderedit.h"
+#include <QMenu>
+#include <QAction>
+#include <QContextMenuEvent>
+#include <QCoreApplication>
+
+enum ColumnIndex {
+    Name = 0,
+    Type = 1,
+    NextTrigger = 2
+};
+
+ActiveReminderList::ActiveReminderList(QWidget *parent)
+    : QWidget(parent)
+    , ui(new Ui::ReminderList)
+    , reminderManager(nullptr)
+    , model(new ActiveReminderTableModel(this))
+    , proxyModel(new QSortFilterProxyModel(this))
+    , editDialog(new ActiveReminderEdit(this))
+{
+    LOG_INFO("创建提醒列表界面");
+    ui->setupUi(this);
+    setupModel();
+    setupConnections();
+    LOG_INFO("提醒列表界面初始化完成");
+}
+
+ActiveReminderList::~ActiveReminderList()
+{
+    LOG_INFO("销毁提醒列表界面");
+    delete ui;
+}
+
+void ActiveReminderList::setReminderManager(ReminderManager *manager)
+{
+    LOG_INFO("设置提醒管理器");
+    reminderManager = manager;
+}
+
+void ActiveReminderList::setupConnections()
+{
+    LOG_INFO("设置信号连接");
+    connect(ui->searchEdit, &QLineEdit::textChanged,
+            this, &ActiveReminderList::onSearchTextChanged);
+    LOG_INFO("信号连接设置完成");
+}
+
+void ActiveReminderList::setupModel()
+{
+    LOG_INFO("设置数据模型");
+    // 设置代理模型
+    proxyModel->setSourceModel(model);
+    proxyModel->setFilterKeyColumn(-1); // 设置为-1表示搜索所有列
+    proxyModel->setFilterCaseSensitivity(Qt::CaseInsensitive); // 不区分大小写
+
+    // 设置表格视图
+    ui->tableView->setModel(proxyModel);
+    ui->tableView->setSelectionBehavior(QAbstractItemView::SelectRows);
+    ui->tableView->setSelectionMode(QAbstractItemView::SingleSelection);
+    ui->tableView->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    ui->tableView->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+    ui->tableView->verticalHeader()->hide();
+    ui->tableView->setAlternatingRowColors(true);
+    ui->tableView->setShowGrid(false);
+    LOG_INFO("数据模型设置完成");
+}
+
+void ActiveReminderList::loadReminders(const QList<Reminder> &reminders)
+{
+    LOG_INFO(QString("加载提醒列表，共 %1 个提醒").arg(reminders.size()));
+    model->loadFromJson(reminders);
+}
+
+QJsonArray ActiveReminderList::getReminders() const
+{
+    return model->saveToJson();
+}
+
+void ActiveReminderList::addNewReminder()
+{
+    LOG_INFO("添加新提醒");
+    editDialog->prepareNewReminder();
+    if (editDialog->exec() == QDialog::Accepted) {
+        Reminder reminder = editDialog->getReminder();
+        if (reminderManager) {
+            reminderManager->addReminder(reminder);
+            addReminderToModel(reminder);
+            reminderManager->saveReminders();
+            LOG_INFO(QString("新提醒添加成功: 名称='%1', ID='%2'")
+                    .arg(reminder.name())
+                    .arg(reminder.id()));
+        }
+    } else {
+        LOG_INFO("取消添加新提醒");
+    }
+}
+
+void ActiveReminderList::addReminderToModel(const Reminder &reminder)
+{
+    LOG_INFO(QString("添加提醒到模型: 名称='%1'").arg(reminder.name()));
+    model->addReminder(reminder);
+    LOG_INFO("提醒已添加到模型");
+}
+
+void ActiveReminderList::updateReminderInModel(const Reminder &reminder)
+{
+    LOG_INFO(QString("更新提醒: 名称='%1'").arg(reminder.name()));
+    
+    // 保存当前选择的ID
+    QString currentId;
+    QModelIndex currentIndex = ui->tableView->currentIndex();
+    if (currentIndex.isValid()) {
+        QModelIndex sourceIndex = proxyModel->mapToSource(currentIndex);
+        if (sourceIndex.isValid()) {
+            currentId = model->getReminder(sourceIndex.row()).id();
+        }
+    }
+    
+    // 更新模型
+    for (int i = 0; i < model->rowCount(); ++i) {
+        Reminder existingReminder = model->getReminder(i);
+        if (existingReminder.id() == reminder.id()) {
+            model->updateReminder(i, reminder);
+            LOG_INFO(QString("提醒更新成功: 名称='%1', 类型=%2")
+                    .arg(reminder.name())
+                    .arg(static_cast<int>(reminder.type())));
+            break;
+        }
+    }
+    
+    // 重置代理模型
+    proxyModel->invalidate();
+    
+    // 恢复选择
+    if (!currentId.isEmpty()) {
+        for (int i = 0; i < model->rowCount(); ++i) {
+            if (model->getReminder(i).id() == currentId) {
+                QModelIndex newIndex = proxyModel->mapFromSource(model->index(i, 0));
+                if (newIndex.isValid()) {
+                    ui->tableView->setCurrentIndex(newIndex);
+                }
+                break;
+            }
+        }
+    }
+}
+
+void ActiveReminderList::editReminder(const QModelIndex &index)
+{
+    QModelIndex sourceIndex = proxyModel->mapToSource(index);
+    Reminder reminder = model->getReminder(sourceIndex.row());
+    LOG_INFO(QString("编辑提醒: 名称='%1'").arg(reminder.name()));
+    
+    editDialog->prepareEditReminder(reminder);
+    if (editDialog->exec() == QDialog::Accepted) {
+        Reminder updatedReminder = editDialog->getReminder();
+        updateReminderInModel(updatedReminder);
+        if (reminderManager) {
+            int index = -1;
+            for (int i = 0; i < reminderManager->getReminders().size(); ++i) {
+                if (reminderManager->getReminders()[i].id() == reminder.id()) {
+                    index = i;
+                    break;
+                }
+            }
+            if (index != -1) {
+                reminderManager->updateReminder(index, updatedReminder);
+                LOG_INFO(QString("提醒管理器更新成功: 名称='%1'").arg(updatedReminder.name()));
+            }
+        }
+    } else {
+        LOG_INFO("取消编辑提醒");
+    }
+}
+
+void ActiveReminderList::deleteReminder(const QModelIndex &index)
+{
+    QModelIndex sourceIndex = proxyModel->mapToSource(index);
+    Reminder reminder = model->getReminder(sourceIndex.row());
+    LOG_INFO(QString("准备删除提醒: 名称='%1'").arg(reminder.name()));
+    
+    QMessageBox::StandardButton reply = QMessageBox::question(
+        this,
+        tr("确认删除"),
+        tr("确定要删除提醒 '%1' 吗？").arg(reminder.name()),
+        QMessageBox::Yes | QMessageBox::No
+    );
+
+    if (reply == QMessageBox::Yes) {
+        model->removeReminder(sourceIndex.row());
+        if (reminderManager) {
+            int index = -1;
+            for (int i = 0; i < reminderManager->getReminders().size(); ++i) {
+                if (reminderManager->getReminders()[i].id() == reminder.id()) {
+                    index = i;
+                    break;
+                }
+            }
+            if (index != -1) {
+                reminderManager->deleteReminder(index);
+                LOG_INFO(QString("提醒删除成功: 名称='%1'").arg(reminder.name()));
+            }
+        }
+    } else {
+        LOG_INFO("取消删除提醒");
+    }
+}
+
+
+void ActiveReminderList::refreshList()
+{
+    LOG_INFO(QString("刷新提醒列表，搜索文本: '%1'").arg(m_searchText));
+    model->search(m_searchText);
+}
+
+void ActiveReminderList::searchReminders(const QString &text)
+{
+    LOG_INFO(QString("搜索提醒: '%1'").arg(text));
+    model->search(text);
+}
+
+QJsonObject ActiveReminderList::getReminderData(const QString &name) const
+{
+    for (int i = 0; i < model->rowCount(); ++i) {
+        Reminder reminder = model->getReminder(i);
+        if (reminder.name() == name) {
+            return reminder.toJson();
+        }
+    }
+    return QJsonObject();
+}
+
+
+void ActiveReminderList::onAddClicked()
+{
+    addNewReminder();
+}
+
+void ActiveReminderList::onEditClicked()
+{
+    QModelIndex currentIndex = ui->tableView->currentIndex();
+    if (currentIndex.isValid()) {
+        editReminder(currentIndex);
+    }
+}
+
+void ActiveReminderList::onDeleteClicked()
+{
+    QModelIndex currentIndex = ui->tableView->currentIndex();
+    if (currentIndex.isValid()) {
+        deleteReminder(currentIndex);
+    }
+}
+
+void ActiveReminderList::onImportClicked()
+{
+    LOG_INFO("开始导入提醒");
+    QString fileName = QFileDialog::getOpenFileName(this,
+        tr("导入提醒"), "",
+        tr("JSON文件 (*.json);;所有文件 (*)"));
+
+    if (fileName.isEmpty()) {
+        LOG_INFO("取消导入提醒");
+        return;
+    }
+
+    LOG_INFO(QString("从文件导入提醒: %1").arg(fileName));
+    QFile file(fileName);
+    if (!file.open(QIODevice::ReadOnly)) {
+        LOG_ERROR(QString("无法打开文件: %1, 错误: %2")
+                 .arg(fileName)
+                 .arg(file.errorString()));
+        QMessageBox::warning(this, tr("错误"),
+            tr("无法打开文件 %1:\n%2").arg(fileName).arg(file.errorString()));
+        return;
+    }
+
+    QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
+    if (doc.isArray()) {
+        QList<Reminder> imported;
+        for (const QJsonValue &value : doc.array()) {
+            Reminder reminder = Reminder::fromJson(value.toObject());
+            imported.append(reminder);
+            if (reminderManager) {
+                reminderManager->addReminder(reminder);
+            }
+        }
+        LOG_INFO(QString("成功导入 %1 个提醒").arg(imported.size()));
+        if (reminderManager) {
+            reminderManager->saveReminders();
+        }
+        loadReminders(imported);
+    } else {
+        LOG_ERROR("导入文件格式错误");
+        QMessageBox::warning(this, tr("错误"),
+            tr("文件格式错误"));
+    }
+}
+
+void ActiveReminderList::onExportClicked()
+{
+    LOG_INFO("开始导出提醒");
+    QString fileName = QFileDialog::getSaveFileName(this,
+        tr("导出提醒"), "",
+        tr("JSON文件 (*.json);;所有文件 (*)"));
+
+    if (fileName.isEmpty()) {
+        LOG_INFO("取消导出提醒");
+        return;
+    }
+
+    LOG_INFO(QString("导出提醒到文件: %1").arg(fileName));
+    QFile file(fileName);
+    if (!file.open(QIODevice::WriteOnly)) {
+        LOG_ERROR(QString("无法保存文件: %1, 错误: %2")
+                 .arg(fileName)
+                 .arg(file.errorString()));
+        QMessageBox::warning(this, tr("错误"),
+            tr("无法保存文件 %1:\n%2").arg(fileName).arg(file.errorString()));
+        return;
+    }
+
+    QJsonDocument doc(getReminders());
+    file.write(doc.toJson());
+    LOG_INFO(QString("成功导出 %1 个提醒").arg(doc.array().size()));
+}
+
+void ActiveReminderList::onSearchTextChanged(const QString &text)
+{
+    LOG_INFO(QString("搜索文本变更: '%1'").arg(text));
+    m_searchText = text;
+    searchReminders(text);
+}
+
+QPushButton *ActiveReminderList::addButton() const
+{
+    return ui->addButton;
+}
+
+QPushButton *ActiveReminderList::deleteButton() const
+{
+    return ui->deleteButton;
+}
+
+QPushButton *ActiveReminderList::importButton() const
+{
+    return ui->importButton;
+}
+
+QPushButton *ActiveReminderList::exportButton() const
+{
+    return ui->exportButton;
+}
+
+QTableView *ActiveReminderList::tableView() const
+{
+    return ui->tableView;
+}

--- a/src/active_reminderlist.h
+++ b/src/active_reminderlist.h
@@ -1,0 +1,63 @@
+#ifndef ACTIVE_REMINDERLIST_H
+#define ACTIVE_REMINDERLIST_H
+
+#include <QWidget>
+#include <QSortFilterProxyModel>
+#include <QJsonObject>
+#include <QJsonArray>
+#include "active_reminderedit.h"
+#include "remindermanager.h"
+#include "active_remindertablemodel.h"
+#include <QPushButton>
+#include <QTableView>
+
+QT_BEGIN_NAMESPACE
+namespace Ui { class ReminderList; }
+QT_END_NAMESPACE
+
+class ActiveReminderList : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit ActiveReminderList(QWidget *parent = nullptr);
+     ~ActiveReminderList();
+
+    void setReminderManager(ReminderManager *manager);
+    void loadReminders(const QList<Reminder> &reminders);
+    QJsonArray getReminders() const;
+    QPushButton *addButton() const;
+    QPushButton *deleteButton() const;
+    QPushButton *importButton() const;
+    QPushButton *exportButton() const;
+    QTableView *tableView() const;
+
+public slots:
+    void onAddClicked();
+    void onEditClicked();
+    void onDeleteClicked();
+    void onImportClicked();
+    void onExportClicked();
+    void onSearchTextChanged(const QString &text);
+
+private:
+    void setupConnections();
+    void setupModel();
+    void addNewReminder();
+    void editReminder(const QModelIndex &index);
+    void deleteReminder(const QModelIndex &index);
+    void refreshList();
+    void searchReminders(const QString &text);
+    QJsonObject getReminderData(const QString &name) const;
+    void addReminderToModel(const Reminder &reminder);
+    void updateReminderInModel(const Reminder &reminder);
+
+    Ui::ReminderList *ui;
+    ReminderManager *reminderManager;
+    ActiveReminderTableModel *model;
+    QSortFilterProxyModel *proxyModel;
+    ActiveReminderEdit *editDialog;
+    QString m_searchText;
+};
+
+#endif // ACTIVE_REMINDERLIST_H

--- a/src/active_remindertablemodel.cpp
+++ b/src/active_remindertablemodel.cpp
@@ -1,0 +1,183 @@
+#include "active_remindertablemodel.h"
+#include <QJsonArray>
+#include <QJsonObject>
+
+ActiveReminderTableModel::ActiveReminderTableModel(QObject *parent)
+    : QAbstractTableModel(parent)
+    , m_isFiltered(false)
+{
+}
+
+int ActiveReminderTableModel::rowCount(const QModelIndex &parent) const
+{
+    if (parent.isValid())
+        return 0;
+    return m_isFiltered ? m_filteredReminders.size() : m_reminders.size();
+}
+
+int ActiveReminderTableModel::columnCount(const QModelIndex &parent) const
+{
+    if (parent.isValid())
+        return 0;
+    return 3;
+}
+
+QVariant ActiveReminderTableModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid())
+        return QVariant();
+
+    const Reminder &reminder = m_isFiltered ? m_filteredReminders[index.row()] : m_reminders[index.row()];
+
+    if (role == Qt::DisplayRole || role == Qt::EditRole) {
+        switch (index.column()) {
+        case 0:
+            return reminder.name();
+        case 1:
+            switch (reminder.type()) {
+            case Reminder::Type::Once: return "一次性";
+            case Reminder::Type::Daily: return "每天";
+            default: return "未知";
+            }
+        case 2:
+            return reminder.nextTrigger().toString("yyyy-MM-dd hh:mm:ss");
+        }
+    }
+    return QVariant();
+}
+
+QVariant ActiveReminderTableModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if (role != Qt::DisplayRole)
+        return QVariant();
+
+    if (orientation == Qt::Horizontal) {
+        switch (section) {
+        case 0: return "名称";
+        case 1: return "类型";
+        case 2: return "下次触发时间";
+        }
+    }
+    return QVariant();
+}
+
+bool ActiveReminderTableModel::setData(const QModelIndex &index, const QVariant &value, int role)
+{
+    if (!index.isValid() || role != Qt::EditRole)
+        return false;
+
+    int row = index.row();
+    if (m_isFiltered) {
+        if (row >= m_filteredReminders.size())
+            return false;
+        row = m_reminders.indexOf(m_filteredReminders[row]);
+    }
+
+    if (row >= m_reminders.size())
+        return false;
+
+    Reminder &reminder = m_reminders[row];
+    switch (index.column()) {
+    case 0:
+        reminder.setName(value.toString());
+        break;
+    default:
+        return false;
+    }
+
+    emit dataChanged(index, index);
+    return true;
+}
+
+Qt::ItemFlags ActiveReminderTableModel::flags(const QModelIndex &index) const
+{
+    if (!index.isValid())
+        return Qt::NoItemFlags;
+
+    Qt::ItemFlags flags = QAbstractTableModel::flags(index);
+    if (index.column() == 0)
+        flags |= Qt::ItemIsEditable;
+    return flags;
+}
+
+void ActiveReminderTableModel::addReminder(const Reminder &reminder)
+{
+    beginInsertRows(QModelIndex(), m_reminders.size(), m_reminders.size());
+    m_reminders.append(reminder);
+    endInsertRows();
+    updateFilteredList();
+}
+
+void ActiveReminderTableModel::updateReminder(int row, const Reminder &reminder)
+{
+    if (row < 0 || row >= m_reminders.size())
+        return;
+
+    m_reminders[row] = reminder;
+    emit dataChanged(index(row, 0), index(row, columnCount() - 1));
+    updateFilteredList();
+}
+
+void ActiveReminderTableModel::removeReminder(int row)
+{
+    if (row < 0 || row >= m_reminders.size())
+        return;
+
+    beginRemoveRows(QModelIndex(), row, row);
+    m_reminders.removeAt(row);
+    endRemoveRows();
+    updateFilteredList();
+}
+
+Reminder ActiveReminderTableModel::getReminder(int row) const
+{
+    if (row < 0 || row >= m_reminders.size())
+        return Reminder();
+    return m_reminders[row];
+}
+
+QVector<Reminder> ActiveReminderTableModel::getAllReminders() const
+{
+    return m_reminders;
+}
+
+void ActiveReminderTableModel::loadFromJson(const QList<Reminder> &reminders)
+{
+    beginResetModel();
+    m_reminders = reminders;
+    endResetModel();
+}
+
+QJsonArray ActiveReminderTableModel::saveToJson() const
+{
+    QJsonArray array;
+    for (const Reminder &reminder : m_reminders) {
+        array.append(reminder.toJson());
+    }
+    return array;
+}
+
+
+void ActiveReminderTableModel::search(const QString &text)
+{
+    m_searchText = text;
+    updateFilteredList();
+}
+
+void ActiveReminderTableModel::updateFilteredList()
+{
+    if (m_searchText.isEmpty()) {
+        m_isFiltered = false;
+        emit layoutChanged();
+        return;
+    }
+
+    m_filteredReminders.clear();
+    for (const Reminder &reminder : m_reminders) {
+        if (reminder.name().contains(m_searchText, Qt::CaseInsensitive)) {
+            m_filteredReminders.append(reminder);
+        }
+    }
+    m_isFiltered = true;
+    emit layoutChanged();
+}

--- a/src/active_remindertablemodel.h
+++ b/src/active_remindertablemodel.h
@@ -1,0 +1,46 @@
+#ifndef ACTIVE_REMINDERTABLEMODEL_H
+#define ACTIVE_REMINDERTABLEMODEL_H
+
+#include <QAbstractTableModel>
+#include <QVector>
+#include "reminder.h"
+
+class ActiveReminderTableModel : public QAbstractTableModel
+{
+    Q_OBJECT
+
+public:
+    explicit ActiveReminderTableModel(QObject *parent = nullptr);
+
+    // 重写QAbstractTableModel的虚函数
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+    bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
+    Qt::ItemFlags flags(const QModelIndex &index) const override;
+
+    // 提醒管理函数
+    void addReminder(const Reminder &reminder);
+    void updateReminder(int row, const Reminder &reminder);
+    void removeReminder(int row);
+    Reminder getReminder(int row) const;
+
+    // JSON序列化
+    void loadFromJson(const QList<Reminder> &reminders);
+    QJsonArray saveToJson() const;
+
+    // 搜索功能
+    void search(const QString &text);
+
+private:
+    void updateFilteredList();
+    QVector<Reminder> getAllReminders() const;
+
+    QVector<Reminder> m_reminders;
+    QVector<Reminder> m_filteredReminders;
+    QString m_searchText;
+    bool m_isFiltered;
+};
+
+#endif // ACTIVE_REMINDERTABLEMODEL_H

--- a/src/activereminderwindow.cpp
+++ b/src/activereminderwindow.cpp
@@ -19,7 +19,7 @@ ActiveReminderWindow::ActiveReminderWindow(QWidget *parent)
         connect(ui->activeList->importButton(), &QPushButton::clicked,
                 this, [this]() { ui->activeList->onImportClicked(); refreshReminders(); });
         connect(ui->activeList->exportButton(), &QPushButton::clicked,
-                ui->activeList, &ReminderList::onExportClicked);
+                ui->activeList, &ActiveReminderList::onExportClicked);
         connect(ui->activeList->tableView(), &QTableView::doubleClicked,
                 this, [this](const QModelIndex &) { ui->activeList->onEditClicked(); refreshReminders(); });
     }

--- a/src/activereminderwindow.h
+++ b/src/activereminderwindow.h
@@ -2,7 +2,7 @@
 #define ACTIVEREMINDERWINDOW_H
 
 #include <QWidget>
-#include "reminderlist.h"
+#include "active_reminderlist.h"
 
 namespace Ui {
 class ActiveReminderWindow;

--- a/src/activereminderwindow.ui
+++ b/src/activereminderwindow.ui
@@ -17,7 +17,7 @@
    <item>
     <layout class="QVBoxLayout" name="verticalLayout">
      <item>
-      <widget class="ReminderList" name="activeList" native="true"/>
+      <widget class="ActiveReminderList" name="activeList" native="true"/>
      </item>
     </layout>
    </item>
@@ -25,9 +25,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>ReminderList</class>
+   <class>ActiveReminderList</class>
    <extends>QWidget</extends>
-   <header>reminderlist.h</header>
+   <header>active_reminderlist.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/completed_reminderedit.cpp
+++ b/src/completed_reminderedit.cpp
@@ -1,0 +1,189 @@
+#include "completed_reminderedit.h"
+#include "ui_reminderedit.h"
+#include <QMessageBox>
+#include <QUuid>
+#include <QDateTime>
+#include <QFile>
+#include <QPushButton>
+#include "logger.h"
+
+
+CompletedReminderEdit::CompletedReminderEdit(QWidget *parent)
+    : QDialog(parent)
+    , ui(new Ui::ReminderEdit)
+{
+    LOG_INFO("创建提醒编辑对话框");
+    ui->setupUi(this);
+    setupConnections();
+    LOG_INFO("提醒编辑对话框初始化完成");
+}
+
+CompletedReminderEdit::~CompletedReminderEdit()
+{
+    LOG_INFO("销毁提醒编辑对话框");
+    delete ui;
+}
+
+void CompletedReminderEdit::prepareNewReminder()
+{
+    LOG_INFO("初始化新建提醒");
+    setWindowTitle(tr("新增提醒"));
+
+    ui->nameEdit->clear();
+    QDateTime now = QDateTime::currentDateTime();
+    ui->dateTimeEdit->setDateTime(now);
+    ui->timeEdit->setTime(now.time());
+    ui->typeCombo->setCurrentIndex(0);
+
+    m_reminder = Reminder();
+    m_reminder.setId(QUuid::createUuid().toString(QUuid::WithoutBraces));
+    m_reminder.setType(Reminder::Type::Once);
+    m_reminder.setNextTrigger(now);
+
+    onTypeChanged(0);
+    LOG_INFO("新建提醒准备完成");
+}
+
+void CompletedReminderEdit::setupConnections()
+{
+    connect(ui->typeCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, &CompletedReminderEdit::onTypeChanged);
+    connect(ui->dateTimeEdit, &QDateTimeEdit::dateTimeChanged,
+            this, &CompletedReminderEdit::onDateTimeChanged);
+    connect(ui->buttonBox, &QDialogButtonBox::accepted,
+            this, &CompletedReminderEdit::onOkClicked);
+    connect(ui->buttonBox, &QDialogButtonBox::rejected,
+            this, &CompletedReminderEdit::onCancelClicked);
+}
+
+void CompletedReminderEdit::prepareEditReminder(const Reminder &reminder)
+{
+    LOG_INFO("加载待编辑的提醒数据");
+    setWindowTitle(tr("编辑提醒"));
+
+    m_reminder = reminder;
+    ui->nameEdit->setText(reminder.name());
+
+    int type = static_cast<int>(reminder.type());
+    ui->typeCombo->setCurrentIndex(type);
+
+    QDateTime nextTrigger = reminder.nextTrigger();
+    if (reminder.type() == Reminder::Type::Once) {
+        ui->dateTimeEdit->setDateTime(nextTrigger);
+    } else {
+        ui->timeEdit->setTime(nextTrigger.time());
+    }
+
+    onTypeChanged(type);
+    LOG_INFO("编辑提醒准备完成");
+}
+
+
+Reminder CompletedReminderEdit::getReminder() const
+{
+    return m_reminder;
+}
+
+void CompletedReminderEdit::onTypeChanged(int index)
+{
+    LOG_INFO(QString("提醒类型变更为: %1").arg(index));
+    // 先全部隐藏
+    ui->dateTimeEdit->hide();
+    ui->timeEdit->hide();
+    ui->dateTimeLabel->hide();
+    ui->timeLabel->hide();
+
+    switch (index) {
+        case 0: // 一次性
+            ui->dateTimeEdit->show();
+            ui->dateTimeLabel->show();
+            m_reminder.setType(Reminder::Type::Once);
+            break;
+        case 1: // 每天
+            ui->timeEdit->show();
+            ui->timeLabel->show();
+            m_reminder.setType(Reminder::Type::Daily);
+            break;
+    }
+    updateNextTriggerTime();
+}
+
+void CompletedReminderEdit::onDateTimeChanged(const QDateTime &dateTime)
+{
+    LOG_INFO(QString("日期时间变更为: %1").arg(dateTime.toString("yyyy-MM-dd HH:mm:ss")));
+    updateNextTriggerTime();
+}
+
+void CompletedReminderEdit::onOkClicked()
+{
+    LOG_INFO("点击确定按钮");
+    if (validateInput()) {
+        QString name = ui->nameEdit->text().trimmed();
+        m_reminder.setName(name);
+        updateNextTriggerTime();
+
+        LOG_INFO(QString("保存提醒: ID='%1', 名称='%2', 类型='%3'")
+                 .arg(m_reminder.id())
+                 .arg(name)
+                 .arg(static_cast<int>(m_reminder.type())));
+        accept();
+    } else {
+        LOG_WARNING("输入验证失败，无法保存提醒");
+    }
+}
+
+void CompletedReminderEdit::onCancelClicked()
+{
+    LOG_INFO("点击取消按钮，关闭对话框");
+    reject();
+}
+
+void CompletedReminderEdit::onDaysChanged()
+{
+    LOG_INFO("星期/日期选择发生变化");
+    updateNextTriggerTime();
+}
+
+QDateTime CompletedReminderEdit::calculateNextTrigger() const
+{
+    QDateTime now = QDateTime::currentDateTime();
+    QDateTime nextTrigger;
+    Reminder::Type type = static_cast<Reminder::Type>(ui->typeCombo->currentIndex());
+
+    switch (type) {
+        case Reminder::Type::Once: {
+            nextTrigger = ui->dateTimeEdit->dateTime();
+            LOG_INFO(QString("计算一次性提醒时间: %1").arg(nextTrigger.toString("yyyy-MM-dd HH:mm:ss")));
+            break;
+        }
+        case Reminder::Type::Daily: {
+            QTime time = ui->timeEdit->time();
+            nextTrigger = QDateTime(now.date(), time);
+            if (nextTrigger <= now) {
+                nextTrigger = nextTrigger.addDays(1);
+            }
+            LOG_INFO(QString("计算每日提醒时间: %1").arg(nextTrigger.toString("yyyy-MM-dd HH:mm:ss")));
+            break;
+        }
+    }
+
+    return nextTrigger;
+}
+
+bool CompletedReminderEdit::validateInput() const
+{
+    bool isValid = !ui->nameEdit->text().trimmed().isEmpty();
+    ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(isValid);
+    if (!isValid) {
+        LOG_WARNING("提醒名称不能为空");
+    }
+    return isValid;
+}
+
+void CompletedReminderEdit::updateNextTriggerTime()
+{
+    QDateTime nextTime = calculateNextTrigger();
+    ui->nextTriggerLabel->setText(nextTime.toString("yyyy-MM-dd HH:mm:ss"));
+    m_reminder.setNextTrigger(nextTime);
+    LOG_INFO(QString("更新下次触发时间: %1").arg(nextTime.toString("yyyy-MM-dd HH:mm:ss")));
+}

--- a/src/completed_reminderedit.h
+++ b/src/completed_reminderedit.h
@@ -1,0 +1,43 @@
+#ifndef COMPLETED_REMINDEREDIT_H
+#define COMPLETED_REMINDEREDIT_H
+
+#include <QDialog>
+#include "reminder.h"
+#include <QStringList>
+#include <QDateTime>
+
+namespace Ui {
+class ReminderEdit;
+}
+
+class CompletedReminderEdit : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit CompletedReminderEdit(QWidget *parent = nullptr);
+    ~CompletedReminderEdit();
+
+    void prepareEditReminder(const Reminder &reminder);
+    void prepareNewReminder();
+    Reminder getReminder() const;
+
+private slots:
+    void onTypeChanged(int index);
+    void onOkClicked();
+    void onCancelClicked();
+    void onDateTimeChanged(const QDateTime &dateTime);
+    void onDaysChanged();
+
+private:
+    void setupConnections();
+    QDateTime calculateNextTrigger() const;
+    bool validateInput() const;
+    void updateNextTriggerTime();
+
+    Ui::ReminderEdit *ui;
+    Reminder m_reminder;
+
+};
+
+#endif // COMPLETED_REMINDEREDIT_H

--- a/src/completed_reminderlist.cpp
+++ b/src/completed_reminderlist.cpp
@@ -1,0 +1,370 @@
+#include "completed_reminderlist.h"
+#include "ui_reminderlist.h"
+#include <QHeaderView>
+#include <QMessageBox>
+#include <QJsonDocument>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QFile>
+#include <QDateTime>
+#include <QFileDialog>
+#include "remindermanager.h"
+#include "logger.h"
+#include "completed_reminderedit.h"
+#include <QMenu>
+#include <QAction>
+#include <QContextMenuEvent>
+#include <QCoreApplication>
+
+enum ColumnIndex {
+    Name = 0,
+    Type = 1,
+    NextTrigger = 2
+};
+
+CompletedReminderList::CompletedReminderList(QWidget *parent)
+    : QWidget(parent)
+    , ui(new Ui::ReminderList)
+    , reminderManager(nullptr)
+    , model(new CompletedReminderTableModel(this))
+    , proxyModel(new QSortFilterProxyModel(this))
+    , editDialog(new CompletedReminderEdit(this))
+{
+    LOG_INFO("创建提醒列表界面");
+    ui->setupUi(this);
+    setupModel();
+    setupConnections();
+    LOG_INFO("提醒列表界面初始化完成");
+}
+
+CompletedReminderList::~CompletedReminderList()
+{
+    LOG_INFO("销毁提醒列表界面");
+    delete ui;
+}
+
+void CompletedReminderList::setReminderManager(ReminderManager *manager)
+{
+    LOG_INFO("设置提醒管理器");
+    reminderManager = manager;
+}
+
+void CompletedReminderList::setupConnections()
+{
+    LOG_INFO("设置信号连接");
+    connect(ui->searchEdit, &QLineEdit::textChanged,
+            this, &CompletedReminderList::onSearchTextChanged);
+    LOG_INFO("信号连接设置完成");
+}
+
+void CompletedReminderList::setupModel()
+{
+    LOG_INFO("设置数据模型");
+    // 设置代理模型
+    proxyModel->setSourceModel(model);
+    proxyModel->setFilterKeyColumn(-1); // 设置为-1表示搜索所有列
+    proxyModel->setFilterCaseSensitivity(Qt::CaseInsensitive); // 不区分大小写
+
+    // 设置表格视图
+    ui->tableView->setModel(proxyModel);
+    ui->tableView->setSelectionBehavior(QAbstractItemView::SelectRows);
+    ui->tableView->setSelectionMode(QAbstractItemView::SingleSelection);
+    ui->tableView->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    ui->tableView->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+    ui->tableView->verticalHeader()->hide();
+    ui->tableView->setAlternatingRowColors(true);
+    ui->tableView->setShowGrid(false);
+    LOG_INFO("数据模型设置完成");
+}
+
+void CompletedReminderList::loadReminders(const QList<Reminder> &reminders)
+{
+    LOG_INFO(QString("加载提醒列表，共 %1 个提醒").arg(reminders.size()));
+    model->loadFromJson(reminders);
+}
+
+QJsonArray CompletedReminderList::getReminders() const
+{
+    return model->saveToJson();
+}
+
+void CompletedReminderList::addNewReminder()
+{
+    LOG_INFO("添加新提醒");
+    editDialog->prepareNewReminder();
+    if (editDialog->exec() == QDialog::Accepted) {
+        Reminder reminder = editDialog->getReminder();
+        if (reminderManager) {
+            reminderManager->addReminder(reminder);
+            addReminderToModel(reminder);
+            reminderManager->saveReminders();
+            LOG_INFO(QString("新提醒添加成功: 名称='%1', ID='%2'")
+                    .arg(reminder.name())
+                    .arg(reminder.id()));
+        }
+    } else {
+        LOG_INFO("取消添加新提醒");
+    }
+}
+
+void CompletedReminderList::addReminderToModel(const Reminder &reminder)
+{
+    LOG_INFO(QString("添加提醒到模型: 名称='%1'").arg(reminder.name()));
+    model->addReminder(reminder);
+    LOG_INFO("提醒已添加到模型");
+}
+
+void CompletedReminderList::updateReminderInModel(const Reminder &reminder)
+{
+    LOG_INFO(QString("更新提醒: 名称='%1'").arg(reminder.name()));
+    
+    // 保存当前选择的ID
+    QString currentId;
+    QModelIndex currentIndex = ui->tableView->currentIndex();
+    if (currentIndex.isValid()) {
+        QModelIndex sourceIndex = proxyModel->mapToSource(currentIndex);
+        if (sourceIndex.isValid()) {
+            currentId = model->getReminder(sourceIndex.row()).id();
+        }
+    }
+    
+    // 更新模型
+    for (int i = 0; i < model->rowCount(); ++i) {
+        Reminder existingReminder = model->getReminder(i);
+        if (existingReminder.id() == reminder.id()) {
+            model->updateReminder(i, reminder);
+            LOG_INFO(QString("提醒更新成功: 名称='%1', 类型=%2")
+                    .arg(reminder.name())
+                    .arg(static_cast<int>(reminder.type())));
+            break;
+        }
+    }
+    
+    // 重置代理模型
+    proxyModel->invalidate();
+    
+    // 恢复选择
+    if (!currentId.isEmpty()) {
+        for (int i = 0; i < model->rowCount(); ++i) {
+            if (model->getReminder(i).id() == currentId) {
+                QModelIndex newIndex = proxyModel->mapFromSource(model->index(i, 0));
+                if (newIndex.isValid()) {
+                    ui->tableView->setCurrentIndex(newIndex);
+                }
+                break;
+            }
+        }
+    }
+}
+
+void CompletedReminderList::editReminder(const QModelIndex &index)
+{
+    QModelIndex sourceIndex = proxyModel->mapToSource(index);
+    Reminder reminder = model->getReminder(sourceIndex.row());
+    LOG_INFO(QString("编辑提醒: 名称='%1'").arg(reminder.name()));
+    
+    editDialog->prepareEditReminder(reminder);
+    if (editDialog->exec() == QDialog::Accepted) {
+        Reminder updatedReminder = editDialog->getReminder();
+        updateReminderInModel(updatedReminder);
+        if (reminderManager) {
+            int index = -1;
+            for (int i = 0; i < reminderManager->getReminders().size(); ++i) {
+                if (reminderManager->getReminders()[i].id() == reminder.id()) {
+                    index = i;
+                    break;
+                }
+            }
+            if (index != -1) {
+                reminderManager->updateReminder(index, updatedReminder);
+                LOG_INFO(QString("提醒管理器更新成功: 名称='%1'").arg(updatedReminder.name()));
+            }
+        }
+    } else {
+        LOG_INFO("取消编辑提醒");
+    }
+}
+
+void CompletedReminderList::deleteReminder(const QModelIndex &index)
+{
+    QModelIndex sourceIndex = proxyModel->mapToSource(index);
+    Reminder reminder = model->getReminder(sourceIndex.row());
+    LOG_INFO(QString("准备删除提醒: 名称='%1'").arg(reminder.name()));
+    
+    QMessageBox::StandardButton reply = QMessageBox::question(
+        this,
+        tr("确认删除"),
+        tr("确定要删除提醒 '%1' 吗？").arg(reminder.name()),
+        QMessageBox::Yes | QMessageBox::No
+    );
+
+    if (reply == QMessageBox::Yes) {
+        model->removeReminder(sourceIndex.row());
+        if (reminderManager) {
+            int index = -1;
+            for (int i = 0; i < reminderManager->getReminders().size(); ++i) {
+                if (reminderManager->getReminders()[i].id() == reminder.id()) {
+                    index = i;
+                    break;
+                }
+            }
+            if (index != -1) {
+                reminderManager->deleteReminder(index);
+                LOG_INFO(QString("提醒删除成功: 名称='%1'").arg(reminder.name()));
+            }
+        }
+    } else {
+        LOG_INFO("取消删除提醒");
+    }
+}
+
+
+void CompletedReminderList::refreshList()
+{
+    LOG_INFO(QString("刷新提醒列表，搜索文本: '%1'").arg(m_searchText));
+    model->search(m_searchText);
+}
+
+void CompletedReminderList::searchReminders(const QString &text)
+{
+    LOG_INFO(QString("搜索提醒: '%1'").arg(text));
+    model->search(text);
+}
+
+QJsonObject CompletedReminderList::getReminderData(const QString &name) const
+{
+    for (int i = 0; i < model->rowCount(); ++i) {
+        Reminder reminder = model->getReminder(i);
+        if (reminder.name() == name) {
+            return reminder.toJson();
+        }
+    }
+    return QJsonObject();
+}
+
+
+void CompletedReminderList::onAddClicked()
+{
+    addNewReminder();
+}
+
+void CompletedReminderList::onEditClicked()
+{
+    QModelIndex currentIndex = ui->tableView->currentIndex();
+    if (currentIndex.isValid()) {
+        editReminder(currentIndex);
+    }
+}
+
+void CompletedReminderList::onDeleteClicked()
+{
+    QModelIndex currentIndex = ui->tableView->currentIndex();
+    if (currentIndex.isValid()) {
+        deleteReminder(currentIndex);
+    }
+}
+
+void CompletedReminderList::onImportClicked()
+{
+    LOG_INFO("开始导入提醒");
+    QString fileName = QFileDialog::getOpenFileName(this,
+        tr("导入提醒"), "",
+        tr("JSON文件 (*.json);;所有文件 (*)"));
+
+    if (fileName.isEmpty()) {
+        LOG_INFO("取消导入提醒");
+        return;
+    }
+
+    LOG_INFO(QString("从文件导入提醒: %1").arg(fileName));
+    QFile file(fileName);
+    if (!file.open(QIODevice::ReadOnly)) {
+        LOG_ERROR(QString("无法打开文件: %1, 错误: %2")
+                 .arg(fileName)
+                 .arg(file.errorString()));
+        QMessageBox::warning(this, tr("错误"),
+            tr("无法打开文件 %1:\n%2").arg(fileName).arg(file.errorString()));
+        return;
+    }
+
+    QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
+    if (doc.isArray()) {
+        QList<Reminder> imported;
+        for (const QJsonValue &value : doc.array()) {
+            Reminder reminder = Reminder::fromJson(value.toObject());
+            imported.append(reminder);
+            if (reminderManager) {
+                reminderManager->addReminder(reminder);
+            }
+        }
+        LOG_INFO(QString("成功导入 %1 个提醒").arg(imported.size()));
+        if (reminderManager) {
+            reminderManager->saveReminders();
+        }
+        loadReminders(imported);
+    } else {
+        LOG_ERROR("导入文件格式错误");
+        QMessageBox::warning(this, tr("错误"),
+            tr("文件格式错误"));
+    }
+}
+
+void CompletedReminderList::onExportClicked()
+{
+    LOG_INFO("开始导出提醒");
+    QString fileName = QFileDialog::getSaveFileName(this,
+        tr("导出提醒"), "",
+        tr("JSON文件 (*.json);;所有文件 (*)"));
+
+    if (fileName.isEmpty()) {
+        LOG_INFO("取消导出提醒");
+        return;
+    }
+
+    LOG_INFO(QString("导出提醒到文件: %1").arg(fileName));
+    QFile file(fileName);
+    if (!file.open(QIODevice::WriteOnly)) {
+        LOG_ERROR(QString("无法保存文件: %1, 错误: %2")
+                 .arg(fileName)
+                 .arg(file.errorString()));
+        QMessageBox::warning(this, tr("错误"),
+            tr("无法保存文件 %1:\n%2").arg(fileName).arg(file.errorString()));
+        return;
+    }
+
+    QJsonDocument doc(getReminders());
+    file.write(doc.toJson());
+    LOG_INFO(QString("成功导出 %1 个提醒").arg(doc.array().size()));
+}
+
+void CompletedReminderList::onSearchTextChanged(const QString &text)
+{
+    LOG_INFO(QString("搜索文本变更: '%1'").arg(text));
+    m_searchText = text;
+    searchReminders(text);
+}
+
+QPushButton *CompletedReminderList::addButton() const
+{
+    return ui->addButton;
+}
+
+QPushButton *CompletedReminderList::deleteButton() const
+{
+    return ui->deleteButton;
+}
+
+QPushButton *CompletedReminderList::importButton() const
+{
+    return ui->importButton;
+}
+
+QPushButton *CompletedReminderList::exportButton() const
+{
+    return ui->exportButton;
+}
+
+QTableView *CompletedReminderList::tableView() const
+{
+    return ui->tableView;
+}

--- a/src/completed_reminderlist.h
+++ b/src/completed_reminderlist.h
@@ -1,0 +1,63 @@
+#ifndef COMPLETED_REMINDERLIST_H
+#define COMPLETED_REMINDERLIST_H
+
+#include <QWidget>
+#include <QSortFilterProxyModel>
+#include <QJsonObject>
+#include <QJsonArray>
+#include "completed_reminderedit.h"
+#include "remindermanager.h"
+#include "completed_remindertablemodel.h"
+#include <QPushButton>
+#include <QTableView>
+
+QT_BEGIN_NAMESPACE
+namespace Ui { class ReminderList; }
+QT_END_NAMESPACE
+
+class CompletedReminderList : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit CompletedReminderList(QWidget *parent = nullptr);
+     ~CompletedReminderList();
+
+    void setReminderManager(ReminderManager *manager);
+    void loadReminders(const QList<Reminder> &reminders);
+    QJsonArray getReminders() const;
+    QPushButton *addButton() const;
+    QPushButton *deleteButton() const;
+    QPushButton *importButton() const;
+    QPushButton *exportButton() const;
+    QTableView *tableView() const;
+
+public slots:
+    void onAddClicked();
+    void onEditClicked();
+    void onDeleteClicked();
+    void onImportClicked();
+    void onExportClicked();
+    void onSearchTextChanged(const QString &text);
+
+private:
+    void setupConnections();
+    void setupModel();
+    void addNewReminder();
+    void editReminder(const QModelIndex &index);
+    void deleteReminder(const QModelIndex &index);
+    void refreshList();
+    void searchReminders(const QString &text);
+    QJsonObject getReminderData(const QString &name) const;
+    void addReminderToModel(const Reminder &reminder);
+    void updateReminderInModel(const Reminder &reminder);
+
+    Ui::ReminderList *ui;
+    ReminderManager *reminderManager;
+    CompletedReminderTableModel *model;
+    QSortFilterProxyModel *proxyModel;
+    CompletedReminderEdit *editDialog;
+    QString m_searchText;
+};
+
+#endif // COMPLETED_REMINDERLIST_H

--- a/src/completed_remindertablemodel.cpp
+++ b/src/completed_remindertablemodel.cpp
@@ -1,0 +1,183 @@
+#include "completed_remindertablemodel.h"
+#include <QJsonArray>
+#include <QJsonObject>
+
+CompletedReminderTableModel::CompletedReminderTableModel(QObject *parent)
+    : QAbstractTableModel(parent)
+    , m_isFiltered(false)
+{
+}
+
+int CompletedReminderTableModel::rowCount(const QModelIndex &parent) const
+{
+    if (parent.isValid())
+        return 0;
+    return m_isFiltered ? m_filteredReminders.size() : m_reminders.size();
+}
+
+int CompletedReminderTableModel::columnCount(const QModelIndex &parent) const
+{
+    if (parent.isValid())
+        return 0;
+    return 3;
+}
+
+QVariant CompletedReminderTableModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid())
+        return QVariant();
+
+    const Reminder &reminder = m_isFiltered ? m_filteredReminders[index.row()] : m_reminders[index.row()];
+
+    if (role == Qt::DisplayRole || role == Qt::EditRole) {
+        switch (index.column()) {
+        case 0:
+            return reminder.name();
+        case 1:
+            switch (reminder.type()) {
+            case Reminder::Type::Once: return "一次性";
+            case Reminder::Type::Daily: return "每天";
+            default: return "未知";
+            }
+        case 2:
+            return reminder.nextTrigger().toString("yyyy-MM-dd hh:mm:ss");
+        }
+    }
+    return QVariant();
+}
+
+QVariant CompletedReminderTableModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if (role != Qt::DisplayRole)
+        return QVariant();
+
+    if (orientation == Qt::Horizontal) {
+        switch (section) {
+        case 0: return "名称";
+        case 1: return "类型";
+        case 2: return "下次触发时间";
+        }
+    }
+    return QVariant();
+}
+
+bool CompletedReminderTableModel::setData(const QModelIndex &index, const QVariant &value, int role)
+{
+    if (!index.isValid() || role != Qt::EditRole)
+        return false;
+
+    int row = index.row();
+    if (m_isFiltered) {
+        if (row >= m_filteredReminders.size())
+            return false;
+        row = m_reminders.indexOf(m_filteredReminders[row]);
+    }
+
+    if (row >= m_reminders.size())
+        return false;
+
+    Reminder &reminder = m_reminders[row];
+    switch (index.column()) {
+    case 0:
+        reminder.setName(value.toString());
+        break;
+    default:
+        return false;
+    }
+
+    emit dataChanged(index, index);
+    return true;
+}
+
+Qt::ItemFlags CompletedReminderTableModel::flags(const QModelIndex &index) const
+{
+    if (!index.isValid())
+        return Qt::NoItemFlags;
+
+    Qt::ItemFlags flags = QAbstractTableModel::flags(index);
+    if (index.column() == 0)
+        flags |= Qt::ItemIsEditable;
+    return flags;
+}
+
+void CompletedReminderTableModel::addReminder(const Reminder &reminder)
+{
+    beginInsertRows(QModelIndex(), m_reminders.size(), m_reminders.size());
+    m_reminders.append(reminder);
+    endInsertRows();
+    updateFilteredList();
+}
+
+void CompletedReminderTableModel::updateReminder(int row, const Reminder &reminder)
+{
+    if (row < 0 || row >= m_reminders.size())
+        return;
+
+    m_reminders[row] = reminder;
+    emit dataChanged(index(row, 0), index(row, columnCount() - 1));
+    updateFilteredList();
+}
+
+void CompletedReminderTableModel::removeReminder(int row)
+{
+    if (row < 0 || row >= m_reminders.size())
+        return;
+
+    beginRemoveRows(QModelIndex(), row, row);
+    m_reminders.removeAt(row);
+    endRemoveRows();
+    updateFilteredList();
+}
+
+Reminder CompletedReminderTableModel::getReminder(int row) const
+{
+    if (row < 0 || row >= m_reminders.size())
+        return Reminder();
+    return m_reminders[row];
+}
+
+QVector<Reminder> CompletedReminderTableModel::getAllReminders() const
+{
+    return m_reminders;
+}
+
+void CompletedReminderTableModel::loadFromJson(const QList<Reminder> &reminders)
+{
+    beginResetModel();
+    m_reminders = reminders;
+    endResetModel();
+}
+
+QJsonArray CompletedReminderTableModel::saveToJson() const
+{
+    QJsonArray array;
+    for (const Reminder &reminder : m_reminders) {
+        array.append(reminder.toJson());
+    }
+    return array;
+}
+
+
+void CompletedReminderTableModel::search(const QString &text)
+{
+    m_searchText = text;
+    updateFilteredList();
+}
+
+void CompletedReminderTableModel::updateFilteredList()
+{
+    if (m_searchText.isEmpty()) {
+        m_isFiltered = false;
+        emit layoutChanged();
+        return;
+    }
+
+    m_filteredReminders.clear();
+    for (const Reminder &reminder : m_reminders) {
+        if (reminder.name().contains(m_searchText, Qt::CaseInsensitive)) {
+            m_filteredReminders.append(reminder);
+        }
+    }
+    m_isFiltered = true;
+    emit layoutChanged();
+}

--- a/src/completed_remindertablemodel.h
+++ b/src/completed_remindertablemodel.h
@@ -1,0 +1,46 @@
+#ifndef COMPLETED_REMINDERTABLEMODEL_H
+#define COMPLETED_REMINDERTABLEMODEL_H
+
+#include <QAbstractTableModel>
+#include <QVector>
+#include "reminder.h"
+
+class CompletedReminderTableModel : public QAbstractTableModel
+{
+    Q_OBJECT
+
+public:
+    explicit CompletedReminderTableModel(QObject *parent = nullptr);
+
+    // 重写QAbstractTableModel的虚函数
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+    bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
+    Qt::ItemFlags flags(const QModelIndex &index) const override;
+
+    // 提醒管理函数
+    void addReminder(const Reminder &reminder);
+    void updateReminder(int row, const Reminder &reminder);
+    void removeReminder(int row);
+    Reminder getReminder(int row) const;
+
+    // JSON序列化
+    void loadFromJson(const QList<Reminder> &reminders);
+    QJsonArray saveToJson() const;
+
+    // 搜索功能
+    void search(const QString &text);
+
+private:
+    void updateFilteredList();
+    QVector<Reminder> getAllReminders() const;
+
+    QVector<Reminder> m_reminders;
+    QVector<Reminder> m_filteredReminders;
+    QString m_searchText;
+    bool m_isFiltered;
+};
+
+#endif // COMPLETED_REMINDERTABLEMODEL_H

--- a/src/completedreminderwindow.h
+++ b/src/completedreminderwindow.h
@@ -2,7 +2,7 @@
 #define COMPLETEDREMINDERWINDOW_H
 
 #include <QWidget>
-#include "reminderlist.h"
+#include "completed_reminderlist.h"
 
 namespace Ui {
 class CompletedReminderWindow;

--- a/src/completedreminderwindow.ui
+++ b/src/completedreminderwindow.ui
@@ -14,7 +14,7 @@
    <item>
     <layout class="QVBoxLayout" name="verticalLayout">
      <item>
-      <widget class="ReminderList" name="completedList" native="true"/>
+      <widget class="CompletedReminderList" name="completedList" native="true"/>
      </item>
     </layout>
    </item>
@@ -22,9 +22,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>ReminderList</class>
+   <class>CompletedReminderList</class>
    <extends>QWidget</extends>
-   <header>reminderlist.h</header>
+   <header>completed_reminderlist.h</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
## Summary
- implement ActiveReminderEdit and CompletedReminderEdit
- add separate ActiveReminderList and CompletedReminderList
- provide corresponding table models
- hook up new lists in Active/Completed reminder windows
- include new sources in project file

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ecc45b79083318babcb93dbb5852b