### PR TITLE
Refactor ReminderManager API

### DIFF
--- a/src/active_reminderlist.cpp
+++ b/src/active_reminderlist.cpp
@@ -168,17 +168,8 @@ void ActiveReminderList::editReminder(const QModelIndex &index)
         Reminder updatedReminder = editDialog->getReminder();
         updateReminderInModel(updatedReminder);
         if (reminderManager) {
-            int index = -1;
-            for (int i = 0; i < reminderManager->getReminders().size(); ++i) {
-                if (reminderManager->getReminders()[i].id() == reminder.id()) {
-                    index = i;
-                    break;
-                }
-            }
-            if (index != -1) {
-                reminderManager->updateReminder(index, updatedReminder);
-                LOG_INFO(QString("提醒管理器更新成功: 名称='%1'").arg(updatedReminder.name()));
-            }
+            reminderManager->updateReminder(updatedReminder);
+            LOG_INFO(QString("提醒管理器更新成功: 名称='%1'").arg(updatedReminder.name()));
         }
     } else {
         LOG_INFO("取消编辑提醒");
@@ -201,17 +192,8 @@ void ActiveReminderList::deleteReminder(const QModelIndex &index)
     if (reply == QMessageBox::Yes) {
         model->removeReminder(sourceIndex.row());
         if (reminderManager) {
-            int index = -1;
-            for (int i = 0; i < reminderManager->getReminders().size(); ++i) {
-                if (reminderManager->getReminders()[i].id() == reminder.id()) {
-                    index = i;
-                    break;
-                }
-            }
-            if (index != -1) {
-                reminderManager->deleteReminder(index);
-                LOG_INFO(QString("提醒删除成功: 名称='%1'").arg(reminder.name()));
-            }
+            reminderManager->deleteReminder(reminder);
+            LOG_INFO(QString("提醒删除成功: 名称='%1'").arg(reminder.name()));
         }
     } else {
         LOG_INFO("取消删除提醒");

--- a/src/completed_reminderlist.cpp
+++ b/src/completed_reminderlist.cpp
@@ -168,17 +168,8 @@ void CompletedReminderList::editReminder(const QModelIndex &index)
         Reminder updatedReminder = editDialog->getReminder();
         updateReminderInModel(updatedReminder);
         if (reminderManager) {
-            int index = -1;
-            for (int i = 0; i < reminderManager->getReminders().size(); ++i) {
-                if (reminderManager->getReminders()[i].id() == reminder.id()) {
-                    index = i;
-                    break;
-                }
-            }
-            if (index != -1) {
-                reminderManager->updateReminder(index, updatedReminder);
-                LOG_INFO(QString("提醒管理器更新成功: 名称='%1'").arg(updatedReminder.name()));
-            }
+            reminderManager->updateReminder(updatedReminder);
+            LOG_INFO(QString("提醒管理器更新成功: 名称='%1'").arg(updatedReminder.name()));
         }
     } else {
         LOG_INFO("取消编辑提醒");
@@ -201,17 +192,8 @@ void CompletedReminderList::deleteReminder(const QModelIndex &index)
     if (reply == QMessageBox::Yes) {
         model->removeReminder(sourceIndex.row());
         if (reminderManager) {
-            int index = -1;
-            for (int i = 0; i < reminderManager->getReminders().size(); ++i) {
-                if (reminderManager->getReminders()[i].id() == reminder.id()) {
-                    index = i;
-                    break;
-                }
-            }
-            if (index != -1) {
-                reminderManager->deleteReminder(index);
-                LOG_INFO(QString("提醒删除成功: 名称='%1'").arg(reminder.name()));
-            }
+            reminderManager->deleteReminder(reminder);
+            LOG_INFO(QString("提醒删除成功: 名称='%1'").arg(reminder.name()));
         }
     } else {
         LOG_INFO("取消删除提醒");

--- a/src/remindermanager.cpp
+++ b/src/remindermanager.cpp
@@ -53,19 +53,25 @@ void ReminderManager::addReminder(const Reminder &reminder)
     saveReminders();
 }
 
-void ReminderManager::updateReminder(int index, const Reminder &reminder)
+void ReminderManager::updateReminder(const Reminder &reminder)
 {
-    if (index >= 0 && index < m_reminders.size()) {
-        m_reminders[index] = reminder;
-        saveReminders();
+    for (int i = 0; i < m_reminders.size(); ++i) {
+        if (m_reminders[i].id() == reminder.id()) {
+            m_reminders[i] = reminder;
+            saveReminders();
+            break;
+        }
     }
 }
 
-void ReminderManager::deleteReminder(int index)
+void ReminderManager::deleteReminder(const Reminder &reminder)
 {
-    if (index >= 0 && index < m_reminders.size()) {
-        m_reminders.removeAt(index);
-        saveReminders();
+    for (int i = 0; i < m_reminders.size(); ++i) {
+        if (m_reminders[i].id() == reminder.id()) {
+            m_reminders.removeAt(i);
+            saveReminders();
+            break;
+        }
     }
 }
 

--- a/src/remindermanager.h
+++ b/src/remindermanager.h
@@ -18,8 +18,8 @@ public:
     ~ReminderManager();
 
     void addReminder(const Reminder &reminder);
-    void updateReminder(int index, const Reminder &reminder);
-    void deleteReminder(int index);
+    void updateReminder(const Reminder &reminder);
+    void deleteReminder(const Reminder &reminder);
     QVector<Reminder> getReminders() const;
 
     void pauseAll();


### PR DESCRIPTION
## Summary
- refactor ReminderManager to update/delete reminders by ID rather than index
- clean up reminder list logic using new API

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f877f405483319b6f15a5c6bd63ed