### PR TITLE
Split reminder UI for active and completed lists

### DIFF
--- a/EasyNotify.pro
+++ b/EasyNotify.pro
@@ -45,7 +45,8 @@ HEADERS += \
 
 FORMS += \
     src/mainwindow.ui \
-    src/reminderlist.ui \
+    src/active_reminderlist.ui \
+    src/completed_reminderlist.ui \
     src/reminderedit.ui \
     src/notificationPopup.ui \
     src/activereminderwindow.ui \

--- a/src/active_reminderlist.cpp
+++ b/src/active_reminderlist.cpp
@@ -1,5 +1,5 @@
 #include "active_reminderlist.h"
-#include "ui_reminderlist.h"
+#include "ui_active_reminderlist.h"
 #include <QHeaderView>
 #include <QMessageBox>
 #include <QJsonDocument>
@@ -24,7 +24,7 @@ enum ColumnIndex {
 
 ActiveReminderList::ActiveReminderList(QWidget *parent)
     : QWidget(parent)
-    , ui(new Ui::ReminderList)
+    , ui(new Ui::ActiveReminderList)
     , reminderManager(nullptr)
     , model(new ActiveReminderTableModel(this))
     , proxyModel(new QSortFilterProxyModel(this))

--- a/src/active_reminderlist.h
+++ b/src/active_reminderlist.h
@@ -12,7 +12,7 @@
 #include <QTableView>
 
 QT_BEGIN_NAMESPACE
-namespace Ui { class ReminderList; }
+namespace Ui { class ActiveReminderList; }
 QT_END_NAMESPACE
 
 class ActiveReminderList : public QWidget
@@ -52,7 +52,7 @@ private:
     void addReminderToModel(const Reminder &reminder);
     void updateReminderInModel(const Reminder &reminder);
 
-    Ui::ReminderList *ui;
+    Ui::ActiveReminderList *ui;
     ReminderManager *reminderManager;
     ActiveReminderTableModel *model;
     QSortFilterProxyModel *proxyModel;

--- a/src/active_reminderlist.ui
+++ b/src/active_reminderlist.ui
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ActiveReminderList</class>
+ <widget class="QWidget" name="ActiveReminderList">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>531</width>
+    <height>310</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>提醒列表</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLineEdit" name="searchEdit">
+       <property name="placeholderText">
+        <string>搜索提醒...</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="addButton">
+       <property name="text">
+        <string>添加</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="deleteButton">
+       <property name="text">
+        <string>删除</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="importButton">
+       <property name="text">
+        <string>导入</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="exportButton">
+       <property name="text">
+        <string>导出</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QTableView" name="tableView">
+     <property name="selectionMode">
+      <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectionBehavior::SelectRows</enum>
+     </property>
+     <property name="showGrid">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/completed_reminderlist.cpp
+++ b/src/completed_reminderlist.cpp
@@ -1,5 +1,5 @@
 #include "completed_reminderlist.h"
-#include "ui_reminderlist.h"
+#include "ui_completed_reminderlist.h"
 #include <QHeaderView>
 #include <QMessageBox>
 #include <QJsonDocument>
@@ -24,7 +24,7 @@ enum ColumnIndex {
 
 CompletedReminderList::CompletedReminderList(QWidget *parent)
     : QWidget(parent)
-    , ui(new Ui::ReminderList)
+    , ui(new Ui::CompletedReminderList)
     , reminderManager(nullptr)
     , model(new CompletedReminderTableModel(this))
     , proxyModel(new QSortFilterProxyModel(this))

--- a/src/completed_reminderlist.h
+++ b/src/completed_reminderlist.h
@@ -12,7 +12,7 @@
 #include <QTableView>
 
 QT_BEGIN_NAMESPACE
-namespace Ui { class ReminderList; }
+namespace Ui { class CompletedReminderList; }
 QT_END_NAMESPACE
 
 class CompletedReminderList : public QWidget
@@ -52,7 +52,7 @@ private:
     void addReminderToModel(const Reminder &reminder);
     void updateReminderInModel(const Reminder &reminder);
 
-    Ui::ReminderList *ui;
+    Ui::CompletedReminderList *ui;
     ReminderManager *reminderManager;
     CompletedReminderTableModel *model;
     QSortFilterProxyModel *proxyModel;

--- a/src/completed_reminderlist.ui
+++ b/src/completed_reminderlist.ui
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CompletedReminderList</class>
+ <widget class="QWidget" name="CompletedReminderList">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>531</width>
+    <height>310</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>提醒列表</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLineEdit" name="searchEdit">
+       <property name="placeholderText">
+        <string>搜索提醒...</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="deleteButton">
+       <property name="text">
+        <string>删除</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QTableView" name="tableView">
+     <property name="selectionMode">
+      <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectionBehavior::SelectRows</enum>
+     </property>
+     <property name="showGrid">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/completedreminderwindow.cpp
+++ b/src/completedreminderwindow.cpp
@@ -12,9 +12,6 @@ CompletedReminderWindow::CompletedReminderWindow(QWidget *parent)
     ui->setupUi(this);
 
     if (ui->completedList) {
-        ui->completedList->addButton()->setVisible(false);
-        ui->completedList->importButton()->setVisible(false);
-        ui->completedList->exportButton()->setVisible(false);
         connect(ui->completedList->deleteButton(), &QPushButton::clicked,
                 this, [this]() { ui->completedList->onDeleteClicked(); refreshReminders(); });
     }


### PR DESCRIPTION
## Summary
- add `active_reminderlist.ui` and `completed_reminderlist.ui`
- reference new UI headers in reminder list classes
- stop hiding buttons in `CompletedReminderWindow`
- update project file to generate new UI headers

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f8b37e05483319e0a43d90b4fd37b