### PR TITLE
Clean unused methods from CompletedReminderList

### DIFF
--- a/src/completed_reminderlist.h
+++ b/src/completed_reminderlist.h
@@ -5,7 +5,6 @@
 #include <QSortFilterProxyModel>
 #include <QJsonObject>
 #include <QJsonArray>
-#include "completed_reminderedit.h"
 #include "remindermanager.h"
 #include "completed_remindertablemodel.h"
 #include <QPushButton>
@@ -25,38 +24,24 @@ public:
 
     void setReminderManager(ReminderManager *manager);
     void loadReminders(const QList<Reminder> &reminders);
-    QJsonArray getReminders() const;
-    QPushButton *addButton() const;
     QPushButton *deleteButton() const;
-    QPushButton *importButton() const;
-    QPushButton *exportButton() const;
     QTableView *tableView() const;
 
 public slots:
-    void onAddClicked();
-    void onEditClicked();
     void onDeleteClicked();
-    void onImportClicked();
-    void onExportClicked();
     void onSearchTextChanged(const QString &text);
 
 private:
     void setupConnections();
     void setupModel();
-    void addNewReminder();
-    void editReminder(const QModelIndex &index);
     void deleteReminder(const QModelIndex &index);
     void refreshList();
     void searchReminders(const QString &text);
-    QJsonObject getReminderData(const QString &name) const;
-    void addReminderToModel(const Reminder &reminder);
-    void updateReminderInModel(const Reminder &reminder);
 
     Ui::CompletedReminderList *ui;
     ReminderManager *reminderManager;
     CompletedReminderTableModel *model;
     QSortFilterProxyModel *proxyModel;
-    CompletedReminderEdit *editDialog;
     QString m_searchText;
 };
 


### PR DESCRIPTION
## Summary
- remove unused add/edit/import/export code from `CompletedReminderList`
- clean up related includes and members

## Testing
- `make -v`

------
https://chatgpt.com/codex/tasks/task_e_684f8cac67448331ac2f4c768b41e1db