### PR TITLE
Remove redundant saveReminders call

### DIFF
--- a/src/active_reminderlist.cpp
+++ b/src/active_reminderlist.cpp
@@ -97,7 +97,6 @@ void ActiveReminderList::addNewReminder()
         if (reminderManager) {
             reminderManager->addReminder(reminder);
             addReminderToModel(reminder);
-            reminderManager->saveReminders();
             LOG_INFO(QString("新提醒添加成功: 名称='%1', ID='%2'")
                     .arg(reminder.name())
                     .arg(reminder.id()));
@@ -280,9 +279,6 @@ void ActiveReminderList::onImportClicked()
             }
         }
         LOG_INFO(QString("成功导入 %1 个提醒").arg(imported.size()));
-        if (reminderManager) {
-            reminderManager->saveReminders();
-        }
         loadReminders(imported);
     } else {
         LOG_ERROR("导入文件格式错误");


### PR DESCRIPTION
## Summary
- avoid calling `saveReminders()` after `addReminder()` since `addReminder()` already saves
- streamline importing reminders

## Testing
- `qmake -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb133115483319115edf6a4b19c5d