### PR TITLE
Fix time fields on reminder edit

### DIFF
--- a/src/active_reminderedit.cpp
+++ b/src/active_reminderedit.cpp
@@ -68,11 +68,8 @@ void ActiveReminderEdit::prepareEditReminder(const Reminder &reminder)
     ui->typeCombo->setCurrentIndex(type);
 
     QDateTime nextTrigger = reminder.nextTrigger();
-    if (reminder.type() == Reminder::Type::Once) {
-        ui->dateTimeEdit->setDateTime(nextTrigger);
-    } else {
-        ui->timeEdit->setTime(nextTrigger.time());
-    }
+    ui->dateTimeEdit->setDateTime(nextTrigger);
+    ui->timeEdit->setTime(nextTrigger.time());
 
     onTypeChanged(type);
     LOG_INFO("编辑提醒准备完成");

--- a/src/completed_reminderedit.cpp
+++ b/src/completed_reminderedit.cpp
@@ -68,11 +68,8 @@ void CompletedReminderEdit::prepareEditReminder(const Reminder &reminder)
     ui->typeCombo->setCurrentIndex(type);
 
     QDateTime nextTrigger = reminder.nextTrigger();
-    if (reminder.type() == Reminder::Type::Once) {
-        ui->dateTimeEdit->setDateTime(nextTrigger);
-    } else {
-        ui->timeEdit->setTime(nextTrigger.time());
-    }
+    ui->dateTimeEdit->setDateTime(nextTrigger);
+    ui->timeEdit->setTime(nextTrigger.time());
 
     onTypeChanged(type);
     LOG_INFO("编辑提醒准备完成");


### PR DESCRIPTION
## Summary
- set both `dateTimeEdit` and `timeEdit` when editing reminders

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb8b630308331a41d0f86ac82397d