### PR TITLE
Add title text label in notification popup

### DIFF
--- a/src/notificationPopup.cpp
+++ b/src/notificationPopup.cpp
@@ -30,7 +30,8 @@ NotificationPopup::NotificationPopup(const QString &title,
 
     // 设置标题图标和消息
     ui->titleLabel->setPixmap(QIcon(":/img/tray_icon_active.png").pixmap(20, 20));
-    ui->messageLabel->setText(title + (m_message.isEmpty() ? "" : "\n" + m_message));
+    ui->titleTextLabel->setText(title);
+    ui->messageLabel->setText(m_message);
 
     // 根据优先级选择图标
     QStyle *style = QApplication::style();

--- a/src/notificationPopup.ui
+++ b/src/notificationPopup.ui
@@ -52,6 +52,16 @@
        </widget>
       </item>
       <item>
+       <widget class="QLabel" name="titleTextLabel">
+        <property name="styleSheet">
+         <string>color: #E0E0E0; font-weight: bold; font-size: 14px;</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item>
        <spacer name="horizontalSpacer">
         <property name="orientation">
          <enum>Qt::Orientation::Horizontal</enum>


### PR DESCRIPTION
## Summary
- display notification title in a dedicated label
- style title label with bold text at 14px size
- update constructor logic to set the new label and message content

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68502800887c833197296db5d39881fe