### PR TITLE
Update notification popup icon sizes

### DIFF
--- a/src/notificationPopup.cpp
+++ b/src/notificationPopup.cpp
@@ -30,7 +30,8 @@ NotificationPopup::NotificationPopup(const QString &title,
 
     // 设置标题图标和消息
     ui->titleLabel->setPixmap(QIcon(":/img/tray_icon_active.png").pixmap(32, 32));
-    ui->messageLabel->setText(title + (m_message.isEmpty() ? "" : "\n" + m_message));
+    ui->titleTextLabel->setText(title);
+    ui->messageLabel->setText(m_message);
 
     // 根据优先级选择图标
     QStyle *style = QApplication::style();
@@ -68,8 +69,17 @@ NotificationPopup::NotificationPopup(const QString &title,
     setAttribute(Qt::WA_DeleteOnClose);
 
     // 设置头部和内容区域不同背景色
-    ui->headerWidget->setStyleSheet("background: #353535; border-top-left-radius: 10px; border-top-right-radius: 10px;");
-    ui->contentWidget->setStyleSheet("background: #232323; border-bottom-left-radius: 10px; border-bottom-right-radius: 10px;");
+    // 头部采用稍浅的强调色，并在底部加入边框与内容区域区分
+    ui->headerWidget->setStyleSheet(
+        "background: #3A3F44;"
+        " border-top-left-radius: 10px;"
+        " border-top-right-radius: 10px;"
+        " border-bottom: 1px solid #232323;");
+    // 内容区域保持较暗背景色
+    ui->contentWidget->setStyleSheet(
+        "background: #232323;"
+        " border-bottom-left-radius: 10px;"
+        " border-bottom-right-radius: 10px;");
 }
 
 void NotificationPopup::show()

--- a/src/notificationPopup.cpp
+++ b/src/notificationPopup.cpp
@@ -28,6 +28,12 @@ NotificationPopup::NotificationPopup(const QString &title,
     setAttribute(Qt::WA_StyledBackground);
     setAutoFillBackground(true);
 
+    // Slight shadow to lift the popup off the screen
+    auto *shadow = new QGraphicsDropShadowEffect(this);
+    shadow->setBlurRadius(12);
+    shadow->setOffset(0, 2);
+    setGraphicsEffect(shadow);
+
     // 设置标题图标和消息
     ui->titleLabel->setPixmap(QIcon(":/img/tray_icon_active.png").pixmap(32, 32));
     ui->titleTextLabel->setText(title);
@@ -53,11 +59,11 @@ NotificationPopup::NotificationPopup(const QString &title,
     // 关闭按钮
     connect(ui->closeButton, &QPushButton::clicked, this, &NotificationPopup::close);
     
-    // 只保留淡入动画
-    fadeIn  = new QPropertyAnimation(this, "windowOpacity", this);
-    fadeIn ->setDuration(300);
-    fadeIn ->setStartValue(0);
-    fadeIn ->setEndValue(1);
+    // 淡入动画
+    fadeIn = new QPropertyAnimation(this, "windowOpacity", this);
+    fadeIn->setDuration(300);
+    fadeIn->setStartValue(0);
+    fadeIn->setEndValue(1);
 
     setStyleSheet(R"(
       QWidget {

--- a/src/notificationPopup.cpp
+++ b/src/notificationPopup.cpp
@@ -29,7 +29,7 @@ NotificationPopup::NotificationPopup(const QString &title,
     setAutoFillBackground(true);
 
     // 设置标题图标和消息
-    ui->titleLabel->setPixmap(QIcon(":/img/tray_icon_active.png").pixmap(20, 20));
+    ui->titleLabel->setPixmap(QIcon(":/img/tray_icon_active.png").pixmap(32, 32));
     ui->messageLabel->setText(title + (m_message.isEmpty() ? "" : "\n" + m_message));
 
     // 根据优先级选择图标

--- a/src/notificationPopup.h
+++ b/src/notificationPopup.h
@@ -31,7 +31,7 @@ private:
     static QList<QPointer<NotificationPopup>> s_popups;
     void repositionPopups();
     QScopedPointer<Ui::NotificationPopup> ui;
-    QPropertyAnimation *fadeIn, *fadeOut;
+    QPropertyAnimation *fadeIn;
     QString m_message;
     Priority m_priority;
 };

--- a/src/notificationPopup.ui
+++ b/src/notificationPopup.ui
@@ -64,6 +64,16 @@
        </widget>
       </item>
       <item>
+       <widget class="QLabel" name="titleTextLabel">
+        <property name="styleSheet">
+         <string>color: #E0E0E0; font-weight: bold; font-size: 14px;</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item>
        <spacer name="horizontalSpacer">
         <property name="orientation">
          <enum>Qt::Orientation::Horizontal</enum>

--- a/src/notificationPopup.ui
+++ b/src/notificationPopup.ui
@@ -34,10 +34,22 @@
    </property>
    <item>
     <widget class="QWidget" name="headerWidget">
-     <layout class="QHBoxLayout" name="headerLayout">
-      <property name="spacing">
-       <number>8</number>
-      </property>
+      <layout class="QHBoxLayout" name="headerLayout">
+       <property name="spacing">
+        <number>8</number>
+       </property>
+       <property name="leftMargin">
+        <number>8</number>
+       </property>
+       <property name="topMargin">
+        <number>8</number>
+       </property>
+       <property name="rightMargin">
+        <number>8</number>
+       </property>
+       <property name="bottomMargin">
+        <number>8</number>
+       </property>
       <item>
        <widget class="QLabel" name="titleLabel">
         <property name="text">
@@ -45,8 +57,8 @@
         </property>
         <property name="fixedSize" stdset="0">
          <size>
-          <width>48</width>
-          <height>48</height>
+          <width>32</width>
+          <height>32</height>
          </size>
         </property>
        </widget>
@@ -88,6 +100,18 @@
      <layout class="QHBoxLayout" name="contentLayout">
       <property name="spacing">
        <number>12</number>
+      </property>
+      <property name="leftMargin">
+       <number>8</number>
+      </property>
+      <property name="topMargin">
+       <number>8</number>
+      </property>
+      <property name="rightMargin">
+       <number>8</number>
+      </property>
+      <property name="bottomMargin">
+       <number>8</number>
       </property>
       <item>
        <widget class="QLabel" name="priorityLabel">


### PR DESCRIPTION
## Summary
- use 32x32 icon for title label and keep priority label 24x24
- add margins to the header and content layouts for better spacing

## Testing
- `qmake --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68502801e4c08331aa288c054bf3f964