### PR TITLE
Remove fade-out animation

### DIFF
--- a/src/notificationPopup.cpp
+++ b/src/notificationPopup.cpp
@@ -52,11 +52,11 @@ NotificationPopup::NotificationPopup(const QString &title,
     // 关闭按钮
     connect(ui->closeButton, &QPushButton::clicked, this, &NotificationPopup::close);
     
-    // 只保留淡入动画
-    fadeIn  = new QPropertyAnimation(this, "windowOpacity", this);
-    fadeIn ->setDuration(300);
-    fadeIn ->setStartValue(0);
-    fadeIn ->setEndValue(1);
+    // 淡入动画
+    fadeIn = new QPropertyAnimation(this, "windowOpacity", this);
+    fadeIn->setDuration(300);
+    fadeIn->setStartValue(0);
+    fadeIn->setEndValue(1);
 
     setStyleSheet(R"(
       QWidget {

--- a/src/notificationPopup.h
+++ b/src/notificationPopup.h
@@ -31,7 +31,7 @@ private:
     static QList<QPointer<NotificationPopup>> s_popups;
     void repositionPopups();
     QScopedPointer<Ui::NotificationPopup> ui;
-    QPropertyAnimation *fadeIn, *fadeOut;
+    QPropertyAnimation *fadeIn;
     QString m_message;
     Priority m_priority;
 };


### PR DESCRIPTION
## Summary
- drop fade-out animation and keep only fade-in for popups
- simplify closeEvent logic

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68502806e5e0833188ce6ca4772e2e87