### PR TITLE
Adjust notification popup icon sizes and layout

### DIFF
--- a/src/notificationPopup.cpp
+++ b/src/notificationPopup.cpp
@@ -35,7 +35,7 @@ NotificationPopup::NotificationPopup(const QString &title,
     setGraphicsEffect(shadow);
 
     // 设置标题图标和消息
-    ui->titleLabel->setPixmap(QIcon(":/img/tray_icon_active.png").pixmap(20, 20));
+    ui->titleLabel->setPixmap(QIcon(":/img/tray_icon_active.png").pixmap(32, 32));
     ui->titleTextLabel->setText(title);
     ui->messageLabel->setText(m_message);
 

--- a/src/notificationPopup.ui
+++ b/src/notificationPopup.ui
@@ -38,6 +38,18 @@
       <property name="spacing">
        <number>8</number>
       </property>
+      <property name="leftMargin">
+       <number>8</number>
+      </property>
+      <property name="topMargin">
+       <number>8</number>
+      </property>
+      <property name="rightMargin">
+       <number>8</number>
+      </property>
+      <property name="bottomMargin">
+       <number>8</number>
+      </property>
       <item>
        <widget class="QLabel" name="titleLabel">
         <property name="text">
@@ -45,8 +57,8 @@
         </property>
         <property name="fixedSize" stdset="0">
          <size>
-          <width>48</width>
-          <height>48</height>
+          <width>32</width>
+          <height>32</height>
          </size>
         </property>
        </widget>
@@ -97,7 +109,19 @@
     <widget class="QWidget" name="contentWidget">
      <layout class="QHBoxLayout" name="contentLayout">
       <property name="spacing">
-       <number>12</number>
+       <number>8</number>
+      </property>
+      <property name="leftMargin">
+       <number>8</number>
+      </property>
+      <property name="topMargin">
+       <number>8</number>
+      </property>
+      <property name="rightMargin">
+       <number>8</number>
+      </property>
+      <property name="bottomMargin">
+       <number>8</number>
       </property>
       <item>
        <widget class="QLabel" name="priorityLabel">


### PR DESCRIPTION
## Summary
- set consistent icon sizes for `titleLabel` and `priorityLabel`
- add margins for popup layouts and tweak spacing
- load pixmaps using the new sizes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68503363f3788331acbd23d6b3372863