### PR TITLE
Simplify NotificationPopup parameters

### DIFF
--- a/src/notificationPopup.cpp
+++ b/src/notificationPopup.cpp
@@ -15,12 +15,10 @@
 QList<QPointer<NotificationPopup>> NotificationPopup::s_popups;
 
 NotificationPopup::NotificationPopup(const QString &title,
-                                     const QString &message,
                                      Priority priority,
                                      QWidget *parent)
   : QWidget(nullptr, Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint),
     ui(new Ui::NotificationPopup),
-    m_message(message),
     m_priority(priority)
 {
     ui->setupUi(this);
@@ -36,8 +34,8 @@ NotificationPopup::NotificationPopup(const QString &title,
 
     // 设置标题图标和消息
     ui->titleLabel->setPixmap(QIcon(":/img/tray_icon_active.png").pixmap(32, 32));
-    ui->titleTextLabel->setText(title);
-    ui->messageLabel->setText(m_message);
+    ui->titleTextLabel->clear();
+    ui->messageLabel->setText(title);
 
     // 根据优先级选择图标
     QStyle *style = QApplication::style();

--- a/src/notificationPopup.h
+++ b/src/notificationPopup.h
@@ -18,7 +18,6 @@ class NotificationPopup : public QWidget {
 public:
     using Priority = Reminder::Priority;
     NotificationPopup(const QString &title,
-                      const QString &message = {},
                       Priority priority = Priority::Medium,
                       QWidget *parent = nullptr);
     
@@ -32,6 +31,5 @@ private:
     void repositionPopups();
     QScopedPointer<Ui::NotificationPopup> ui;
     QPropertyAnimation *fadeIn;
-    QString m_message;
     Priority m_priority;
 };

--- a/src/remindermanager.cpp
+++ b/src/remindermanager.cpp
@@ -191,7 +191,7 @@ bool ReminderManager::shouldTrigger(const Reminder &reminder) const
 
 void ReminderManager::showNotification(const Reminder &reminder)
 {
-    NotificationPopup *popup = new NotificationPopup(reminder.name(), {}, reminder.priority());
+    NotificationPopup *popup = new NotificationPopup(reminder.name(), reminder.priority());
     popup->show();
 }
 


### PR DESCRIPTION
## Summary
- remove message field from `NotificationPopup`
- show title text inside the popup message label
- update ReminderManager to use the new constructor

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850376597b08331937e6baed578dd9f