### PR TITLE
Improve logging around crashes and window lifecycle

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,16 +21,19 @@ QString getDumpFilePath() {
 
 // 崩溃处理函数
 LONG WINAPI TopLevelExceptionHandler(EXCEPTION_POINTERS* pExceptionInfo) {
-	static bool isHandling = false;
-	if (isHandling) {
-		return EXCEPTION_CONTINUE_SEARCH;
-	}
-	isHandling = true;
+        static bool isHandling = false;
+        if (isHandling) {
+                return EXCEPTION_CONTINUE_SEARCH;
+        }
+        isHandling = true;
 
-	try {
-		QString dumpPath = getDumpFilePath();
-		HANDLE hFile = CreateFileW(
-			dumpPath.toStdWString().c_str(),
+        // 记录捕获到未处理异常
+        LOG_ERROR("捕获到未处理异常");
+
+        try {
+                QString dumpPath = getDumpFilePath();
+                HANDLE hFile = CreateFileW(
+                        dumpPath.toStdWString().c_str(),
 			GENERIC_WRITE,
 			0,
 			NULL,
@@ -39,26 +42,31 @@ LONG WINAPI TopLevelExceptionHandler(EXCEPTION_POINTERS* pExceptionInfo) {
 			NULL
 		);
 
-		if (hFile != INVALID_HANDLE_VALUE) {
-			MINIDUMP_EXCEPTION_INFORMATION exInfo;
-			exInfo.ExceptionPointers = pExceptionInfo;
-			exInfo.ThreadId = GetCurrentThreadId();
-			exInfo.ClientPointers = TRUE;
+                if (hFile != INVALID_HANDLE_VALUE) {
+                        MINIDUMP_EXCEPTION_INFORMATION exInfo;
+                        exInfo.ExceptionPointers = pExceptionInfo;
+                        exInfo.ThreadId = GetCurrentThreadId();
+                        exInfo.ClientPointers = TRUE;
 
 			// 创建完整的内存转储
-			MiniDumpWriteDump(
-				GetCurrentProcess(),
-				GetCurrentProcessId(),
-				hFile,
-				static_cast<MINIDUMP_TYPE>(MiniDumpNormal | MiniDumpWithFullMemory | MiniDumpWithHandleData),
-				&exInfo,
-				NULL,
-				NULL
-			);
+                        BOOL dumpResult = MiniDumpWriteDump(
+                                GetCurrentProcess(),
+                                GetCurrentProcessId(),
+                                hFile,
+                                static_cast<MINIDUMP_TYPE>(MiniDumpNormal | MiniDumpWithFullMemory | MiniDumpWithHandleData),
+                                &exInfo,
+                                NULL,
+                                NULL
+                        );
 
-			CloseHandle(hFile);
+                        if (!dumpResult) {
+                                DWORD err = GetLastError();
+                                LOG_ERROR(QString("写入转储文件失败(%1): %2").arg(err).arg(dumpPath));
+                        }
 
-			// 记录崩溃信息到日志
+                        CloseHandle(hFile);
+
+                        // 记录崩溃信息到日志
 			LOG_ERROR(QString("程序崩溃，转储文件已保存到: %1").arg(dumpPath));
 			LOG_ERROR(QString("异常代码: 0x%1").arg(pExceptionInfo->ExceptionRecord->ExceptionCode, 8, 16, QChar('0')));
 			LOG_ERROR(QString("异常地址: 0x%1").arg((quintptr)pExceptionInfo->ExceptionRecord->ExceptionAddress, 8, 16, QChar('0')));
@@ -120,12 +128,15 @@ LONG WINAPI TopLevelExceptionHandler(EXCEPTION_POINTERS* pExceptionInfo) {
 
 			// 清理符号处理器
 			SymCleanup(process);
-		}
-	}
-	catch (...) {
-		// 如果转储过程中发生异常，至少记录一下
-		LOG_INFO("程序崩溃，但无法创建转储文件");
-	}
+                } else {
+                        DWORD err = GetLastError();
+                        LOG_ERROR(QString("无法创建转储文件(%1): %2").arg(err).arg(dumpPath));
+                }
+        }
+        catch (...) {
+                // 如果转储过程中发生异常，至少记录一下
+                LOG_INFO("程序崩溃，但无法创建转储文件");
+        }
 
 	return EXCEPTION_CONTINUE_SEARCH;
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -6,6 +6,7 @@
 #include "completedreminderwindow.h"
 #include <QCloseEvent>
 #include "configmanager.h"
+#include "logger.h"
 
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent)
@@ -44,6 +45,7 @@ MainWindow::MainWindow(QWidget *parent)
 
 MainWindow::~MainWindow()
 {
+    LOG_INFO("MainWindow 析构");
     delete activeWindow;
     delete completedWindow;
     delete ui;
@@ -114,6 +116,7 @@ void MainWindow::createActions()
 
 void MainWindow::onTrayIconActivated(QSystemTrayIcon::ActivationReason reason)
 {
+    LOG_DEBUG(QString("托盘图标激活，原因: %1").arg(reason));
     if (reason == QSystemTrayIcon::DoubleClick) {
         onShowMainWindow();
     }
@@ -121,6 +124,7 @@ void MainWindow::onTrayIconActivated(QSystemTrayIcon::ActivationReason reason)
 
 void MainWindow::onShowMainWindow()
 {
+    LOG_DEBUG("显示主界面");
     show();
     if (activeWindow)
         activeWindow->show(), activeWindow->activateWindow(), activeWindow->raise();
@@ -130,6 +134,7 @@ void MainWindow::onShowMainWindow()
 
 void MainWindow::onPauseReminders()
 {
+    LOG_DEBUG("切换提醒暂停状态");
     isPaused = !isPaused;
     if (isPaused) {
         pauseAction->setText(tr("恢复提醒"));
@@ -141,22 +146,29 @@ void MainWindow::onPauseReminders()
         trayIcon->setIcon(QIcon(":/img/tray_icon.png"));
     }
     ConfigManager::instance().setPaused(isPaused);
+    LOG_INFO(QString("提醒已%1").arg(isPaused ? "暂停" : "恢复"));
 }
 
 void MainWindow::onQuit()
 {
+    LOG_INFO("用户选择退出");
     QMessageBox::StandardButton reply;
     reply = QMessageBox::question(this, tr("确认退出"),
                                 tr("确定要退出程序吗？"),
                                 QMessageBox::Yes | QMessageBox::No);
     if (reply == QMessageBox::Yes) {
+        LOG_INFO("用户确认退出");
         QApplication::quit();
+    } else {
+        LOG_INFO("用户取消退出");
     }
 }
 
 void MainWindow::closeEvent(QCloseEvent *event)
 {
+    LOG_DEBUG("closeEvent 触发");
     if (trayIcon->isVisible()) {
+        LOG_DEBUG("托盘图标可见，隐藏窗口");
         hide();
         if (activeWindow)
             activeWindow->hide();
@@ -164,6 +176,7 @@ void MainWindow::closeEvent(QCloseEvent *event)
             completedWindow->hide();
         event->ignore();
     } else {
+        LOG_DEBUG("托盘图标不可见，正常关闭窗口");
         QMainWindow::closeEvent(event);
     }
 }


### PR DESCRIPTION
## Summary
- log when unhandled exceptions are caught
- log dump file creation/write failures
- add MainWindow logging for window and tray events

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851303f6de0833185354022c0b3da9b