### PR TITLE
Add autostart tray option

### DIFF
--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -20,6 +20,8 @@ public:
     // 提醒相关配置
     bool isPaused() const;
     void setPaused(bool paused);
+    bool isAutoStart() const;
+    void setAutoStart(bool autoStart);
     QJsonArray getReminders() const;
     void setReminders(const QJsonArray &reminders);
 
@@ -36,6 +38,7 @@ private:
     static const QString CONFIG_FILE;
     static const QString REMINDERS_KEY;
     static const QString PAUSED_KEY;
+    static const QString AUTO_START_KEY;
 };
 
 #endif // CONFIGMANAGER_H 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -25,6 +25,7 @@ private slots:
     void onTrayIconActivated(QSystemTrayIcon::ActivationReason reason);
     void onShowMainWindow();
     void onPauseReminders();
+    void onToggleAutoStart();
     void onQuit();
 
 private:
@@ -41,8 +42,10 @@ private:
     QMenu *trayIconMenu;
     QAction *showAction;
     QAction *pauseAction;
+    QAction *autoStartAction;
     QAction *quitAction;
     bool isPaused;
+    bool autoStartEnabled;
 
 protected:
     void closeEvent(QCloseEvent *event) override;


### PR DESCRIPTION
## Summary
- add auto-start state to ConfigManager and save it in `config.json`
- add a tray menu action to toggle auto-start

## Testing
- `qmake EasyNotify.pro` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851380cabac8331a149e8d01d41ba10