### PR TITLE
Fix reminder lists not refreshing after restoring from tray

### DIFF
--- a/src/activereminderwindow.cpp
+++ b/src/activereminderwindow.cpp
@@ -3,6 +3,7 @@
 #include <QPushButton>
 #include <QTableView>
 #include <QModelIndex>
+#include <QShowEvent>
 
 ActiveReminderWindow::ActiveReminderWindow(QWidget *parent)
     : QWidget(parent)
@@ -60,4 +61,10 @@ void ActiveReminderWindow::refreshReminders()
             filtered.append(r);
     }
     ui->activeList->loadReminders(filtered);
+}
+
+void ActiveReminderWindow::showEvent(QShowEvent *event)
+{
+    QWidget::showEvent(event);
+    refreshReminders();
 }

--- a/src/activereminderwindow.h
+++ b/src/activereminderwindow.h
@@ -2,6 +2,7 @@
 #define ACTIVEREMINDERWINDOW_H
 
 #include <QWidget>
+#include <QShowEvent>
 #include "active_reminderlist.h"
 
 namespace Ui {
@@ -20,6 +21,9 @@ public:
 
 private slots:
     void refreshReminders();
+
+protected:
+    void showEvent(QShowEvent *event) override;
 
 private:
     Ui::ActiveReminderWindow *ui;

--- a/src/completedreminderwindow.cpp
+++ b/src/completedreminderwindow.cpp
@@ -3,6 +3,7 @@
 #include <QPushButton>
 #include <QTableView>
 #include <QModelIndex>
+#include <QShowEvent>
 
 CompletedReminderWindow::CompletedReminderWindow(QWidget *parent)
     : QWidget(parent)
@@ -45,4 +46,10 @@ void CompletedReminderWindow::refreshReminders()
             filtered.append(r);
     }
     ui->completedList->loadReminders(filtered);
+}
+
+void CompletedReminderWindow::showEvent(QShowEvent *event)
+{
+    QWidget::showEvent(event);
+    refreshReminders();
 }

--- a/src/completedreminderwindow.h
+++ b/src/completedreminderwindow.h
@@ -2,6 +2,7 @@
 #define COMPLETEDREMINDERWINDOW_H
 
 #include <QWidget>
+#include <QShowEvent>
 #include "completed_reminderlist.h"
 
 namespace Ui {
@@ -20,6 +21,9 @@ public:
 
 private slots:
     void refreshReminders();
+
+protected:
+    void showEvent(QShowEvent *event) override;
 
 private:
     Ui::CompletedReminderWindow *ui;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -144,10 +144,8 @@ void MainWindow::onShowMainWindow()
 {
     LOG_DEBUG("显示主界面");
     show();
-    if (activeWindow)
-        activeWindow->show(), activeWindow->activateWindow(), activeWindow->raise();
-    if (completedWindow)
-        completedWindow->show(), completedWindow->activateWindow(), completedWindow->raise();
+    activateWindow();
+    raise();
 }
 
 void MainWindow::onPauseReminders()
@@ -201,10 +199,6 @@ void MainWindow::closeEvent(QCloseEvent *event)
     if (trayIcon->isVisible()) {
         LOG_DEBUG("托盘图标可见，隐藏窗口");
         hide();
-        if (activeWindow)
-            activeWindow->hide();
-        if (completedWindow)
-            completedWindow->hide();
         event->ignore();
     } else {
         LOG_DEBUG("托盘图标不可见，正常关闭窗口");


### PR DESCRIPTION
## Summary
- refresh reminder lists whenever the reminder windows are shown
- avoid showing both tabs at once when restoring from the tray so completed reminders no longer cover the active list

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68516e3b47f48331ac3fab18d9b43a74