### PR TITLE
Add reminder ID deduplication

### DIFF
--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -34,6 +34,7 @@ private:
     void initDefaultConfig();
     void saveConfig();
     void loadConfig();
+    static void deduplicate(QJsonArray &reminders);
     QString getConfigPath() const;
 
     QJsonObject config;

--- a/src/remindermanager.cpp
+++ b/src/remindermanager.cpp
@@ -63,6 +63,12 @@ void ReminderManager::loadReminders()
 void ReminderManager::addReminder(const Reminder &reminder)
 {
     QMutexLocker locker(&mutex);
+    for (const Reminder &r : m_reminders) {
+        if (r.id() == reminder.id()) {
+            LOG_WARNING(QString("尝试添加重复的提醒 ID: %1").arg(reminder.id()));
+            return;
+        }
+    }
     m_reminders.append(reminder);
     saveReminders();
 }


### PR DESCRIPTION
## Summary
- remove duplicate reminders by ID when loading configuration
- deduplicate reminders before saving or returning from ConfigManager
- skip repeated IDs when importing reminder JSON
- prevent duplicate IDs in ReminderManager

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852c4d195888331be6b6c9f00c3945f