### PR TITLE
Fix crash when bulk deleting completed reminders

### DIFF
--- a/src/completed_reminderlist.cpp
+++ b/src/completed_reminderlist.cpp
@@ -134,6 +134,9 @@ void CompletedReminderList::onDeleteClicked()
             }
         }
 
+        // 在删除前清空选区，避免模型更新过程中访问无效索引
+        ui->tableView->clearSelection();
+
         // 按行号从大到小排序，这样删除时不会影响其他行的索引
         std::sort(toDelete.begin(), toDelete.end(),
                  [](const QPair<int, Reminder> &a, const QPair<int, Reminder> &b) {


### PR DESCRIPTION
## Summary
- avoid invalid selection indices by clearing the table selection before removing rows

## Testing
- `qmake -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ce62a7308331bfecd464e17ecb97