### PR TITLE
Fix missing QUrl include

### DIFF
--- a/src/remoteclient.h
+++ b/src/remoteclient.h
@@ -3,6 +3,7 @@
 
 #include <QObject>
 #include <QTcpSocket>
+#include <QUrl>
 
 class RemoteClient : public QObject
 {


### PR DESCRIPTION
## Summary
- include `<QUrl>` in RemoteClient header to fix compilation

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a49ec51ac8331b1ad736ae936dc3a